### PR TITLE
Add event handlers for additional NHL play types and expand summary

### DIFF
--- a/engine/event_handlers/__init__.py
+++ b/engine/event_handlers/__init__.py
@@ -1,9 +1,23 @@
 from .goal import interpret_goal
 from .penalty import interpret_penalty
 from .shot_on_goal import interpret_shot_on_goal
+from .hit import interpret_hit
+from .faceoff import interpret_faceoff
+from .blocked_shot import interpret_blocked_shot
+from .missed_shot import interpret_missed_shot
+from .giveaway import interpret_giveaway
+from .takeaway import interpret_takeaway
+from .delayed_penalty import interpret_delayed_penalty
 
 EVENT_HANDLERS = {
     "goal": interpret_goal,
     "penalty": interpret_penalty,
     "shot-on-goal": interpret_shot_on_goal,
+    "hit": interpret_hit,
+    "faceoff": interpret_faceoff,
+    "blocked-shot": interpret_blocked_shot,
+    "missed-shot": interpret_missed_shot,
+    "giveaway": interpret_giveaway,
+    "takeaway": interpret_takeaway,
+    "delayed-penalty": interpret_delayed_penalty,
 }

--- a/engine/event_handlers/blocked_shot.py
+++ b/engine/event_handlers/blocked_shot.py
@@ -1,0 +1,24 @@
+from typing import Dict, Any
+
+def interpret_blocked_shot(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Interpret a blocked-shot event and return structured LLM-ready data."""
+    details = event.get("details", {})
+    period = event.get("periodDescriptor", {}).get("number")
+    time = event.get("timeInPeriod")
+
+    return {
+        "event_type": "blocked-shot",
+        "players": {
+            "blocker_id": details.get("blockingPlayerId"),
+            "shooter_id": details.get("shootingPlayerId"),
+        },
+        "team_id": details.get("eventOwnerTeamId"),
+        "period": period,
+        "time": time,
+        "zone": details.get("zoneCode"),
+        "reason": details.get("reason"),
+        "location": {
+            "x": details.get("xCoord"),
+            "y": details.get("yCoord"),
+        },
+    }

--- a/engine/event_handlers/delayed_penalty.py
+++ b/engine/event_handlers/delayed_penalty.py
@@ -1,0 +1,19 @@
+from typing import Dict, Any
+
+def interpret_delayed_penalty(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Interpret a delayed-penalty event and return structured LLM-ready data."""
+    details = event.get("details", {})
+    period = event.get("periodDescriptor", {}).get("number")
+    time = event.get("timeInPeriod")
+
+    return {
+        "event_type": "delayed-penalty",
+        "team_id": details.get("eventOwnerTeamId"),
+        "period": period,
+        "time": time,
+        "zone": details.get("zoneCode"),
+        "location": {
+            "x": details.get("xCoord"),
+            "y": details.get("yCoord"),
+        },
+    }

--- a/engine/event_handlers/faceoff.py
+++ b/engine/event_handlers/faceoff.py
@@ -1,0 +1,23 @@
+from typing import Dict, Any
+
+def interpret_faceoff(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Interpret a faceoff event and return structured LLM-ready data."""
+    details = event.get("details", {})
+    period = event.get("periodDescriptor", {}).get("number")
+    time = event.get("timeInPeriod")
+
+    return {
+        "event_type": "faceoff",
+        "players": {
+            "winner_id": details.get("winningPlayerId"),
+            "loser_id": details.get("losingPlayerId"),
+        },
+        "team_id": details.get("eventOwnerTeamId"),
+        "period": period,
+        "time": time,
+        "zone": details.get("zoneCode"),
+        "location": {
+            "x": details.get("xCoord"),
+            "y": details.get("yCoord"),
+        },
+    }

--- a/engine/event_handlers/giveaway.py
+++ b/engine/event_handlers/giveaway.py
@@ -1,0 +1,22 @@
+from typing import Dict, Any
+
+def interpret_giveaway(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Interpret a giveaway event and return structured LLM-ready data."""
+    details = event.get("details", {})
+    period = event.get("periodDescriptor", {}).get("number")
+    time = event.get("timeInPeriod")
+
+    return {
+        "event_type": "giveaway",
+        "players": {
+            "player_id": details.get("playerId"),
+        },
+        "team_id": details.get("eventOwnerTeamId"),
+        "period": period,
+        "time": time,
+        "zone": details.get("zoneCode"),
+        "location": {
+            "x": details.get("xCoord"),
+            "y": details.get("yCoord"),
+        },
+    }

--- a/engine/event_handlers/hit.py
+++ b/engine/event_handlers/hit.py
@@ -1,0 +1,23 @@
+from typing import Dict, Any
+
+def interpret_hit(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Interpret a hit event and return structured LLM-ready data."""
+    details = event.get("details", {})
+    period = event.get("periodDescriptor", {}).get("number")
+    time = event.get("timeInPeriod")
+
+    return {
+        "event_type": "hit",
+        "players": {
+            "hitter_id": details.get("hittingPlayerId"),
+            "hittee_id": details.get("hitteePlayerId"),
+        },
+        "team_id": details.get("eventOwnerTeamId"),
+        "period": period,
+        "time": time,
+        "zone": details.get("zoneCode"),
+        "location": {
+            "x": details.get("xCoord"),
+            "y": details.get("yCoord"),
+        },
+    }

--- a/engine/event_handlers/missed_shot.py
+++ b/engine/event_handlers/missed_shot.py
@@ -1,0 +1,25 @@
+from typing import Dict, Any
+
+def interpret_missed_shot(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Interpret a missed-shot event and return structured LLM-ready data."""
+    details = event.get("details", {})
+    period = event.get("periodDescriptor", {}).get("number")
+    time = event.get("timeInPeriod")
+
+    return {
+        "event_type": "missed-shot",
+        "players": {
+            "shooter_id": details.get("shootingPlayerId"),
+        },
+        "goalie_id": details.get("goalieInNetId"),
+        "team_id": details.get("eventOwnerTeamId"),
+        "period": period,
+        "time": time,
+        "zone": details.get("zoneCode"),
+        "shot_type": details.get("shotType"),
+        "reason": details.get("reason"),
+        "location": {
+            "x": details.get("xCoord"),
+            "y": details.get("yCoord"),
+        },
+    }

--- a/engine/event_handlers/takeaway.py
+++ b/engine/event_handlers/takeaway.py
@@ -1,0 +1,22 @@
+from typing import Dict, Any
+
+def interpret_takeaway(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Interpret a takeaway event and return structured LLM-ready data."""
+    details = event.get("details", {})
+    period = event.get("periodDescriptor", {}).get("number")
+    time = event.get("timeInPeriod")
+
+    return {
+        "event_type": "takeaway",
+        "players": {
+            "player_id": details.get("playerId"),
+        },
+        "team_id": details.get("eventOwnerTeamId"),
+        "period": period,
+        "time": time,
+        "zone": details.get("zoneCode"),
+        "location": {
+            "x": details.get("xCoord"),
+            "y": details.get("yCoord"),
+        },
+    }

--- a/engine/generate_summary.py
+++ b/engine/generate_summary.py
@@ -23,14 +23,28 @@ def generate_summary(events: List[Dict]) -> str:
       "overtime": sum(1 for event in events if event["event_type"] in ["shot-on-goal", "goal"] and event["period"] == 4),
       "shootout": sum(1 for event in events if event["event_type"] in ["shot-on-goal", "goal"] and event["period"] == 5),
     }
-    
+
     sog_count = shots_by_period["regulation"] + shots_by_period["overtime"]
-    
+
     penalty_count = sum(1 for event in events if event["event_type"] == "penalty")
+    hit_count = sum(1 for event in events if event["event_type"] == "hit")
+    faceoff_count = sum(1 for event in events if event["event_type"] == "faceoff")
+    blocked_shot_count = sum(1 for event in events if event["event_type"] == "blocked-shot")
+    missed_shot_count = sum(1 for event in events if event["event_type"] == "missed-shot")
+    giveaway_count = sum(1 for event in events if event["event_type"] == "giveaway")
+    takeaway_count = sum(1 for event in events if event["event_type"] == "takeaway")
+    delayed_penalty_count = sum(1 for event in events if event["event_type"] == "delayed-penalty")
 
     return (
         f"Game Summary:\n"
         f"- Goals scored: {goal_count} (Reg: {goals_by_period['regulation']}, OT: {goals_by_period['overtime']}, SO: {goals_by_period['shootout']})\n"
         f"- Shots on goal: {sog_count} (Reg: {shots_by_period['regulation']}, OT: {shots_by_period['overtime']}, SO excluded)\n"
         f"- Penalties: {penalty_count}\n"
+        f"- Hits: {hit_count}\n"
+        f"- Faceoffs: {faceoff_count}\n"
+        f"- Blocked shots: {blocked_shot_count}\n"
+        f"- Missed shots: {missed_shot_count}\n"
+        f"- Giveaways: {giveaway_count}\n"
+        f"- Takeaways: {takeaway_count}\n"
+        f"- Delayed penalties: {delayed_penalty_count}\n"
     )


### PR DESCRIPTION
## Summary
- add dedicated handlers for hits, faceoffs, blocked shots, missed shots, giveaways, takeaways, and delayed penalties
- register new handlers in the event handler registry and extend summary generation to tally each event type

## Testing
- `pytest -q`
- `python - <<'PY'
import json
from engine.transform import transform_event
from engine.generate_summary import generate_summary

events = []
with open('data/events/2024021182.jsonl') as f:
    for line in f:
        obj = json.loads(line)
        if 'raw_data' in obj:
            events.append(transform_event(obj['raw_data']))
        else:
            events.append(obj)

print(generate_summary(events))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68961f63ab34832bb170397a04b5cbfc