### PR TITLE
Handle missing event types in transform_event

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,3 @@
+"""Core engine modules for processing NHL events."""
+
+__all__ = ["transform_event"]

--- a/engine/transform.py
+++ b/engine/transform.py
@@ -11,7 +11,11 @@ def transform_event(event: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         Dict[str, Any]: Normalized dictionary describing the event.
     """
-    event_type = event.get("typeDescKey").lower()
+    # Gracefully handle missing or null event types.
+    # Some API events may omit ``typeDescKey`` which would cause ``NoneType``
+    # errors when calling ``lower()``. Defaulting to an empty string ensures
+    # we return an ``unknown`` event instead of raising an exception.
+    event_type = event.get("typeDescKey", "").lower()
     handler = EVENT_HANDLERS.get(event_type)
 
     if handler:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,14 @@
+import pytest
+
+from engine.transform import transform_event
+
+
+def test_transform_handles_missing_type_desc_key():
+    """A missing typeDescKey should result in an unknown event instead of errors."""
+    event = {
+        # No 'typeDescKey' field
+        "details": {},
+    }
+    result = transform_event(event)
+    assert result["event_type"] == "unknown"
+    assert result["raw_data"] == event


### PR DESCRIPTION
## Summary
- avoid NoneType errors when typeDescKey is missing by defaulting to empty string
- expose engine package and add regression test for missing typeDescKey

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961c956858832baba58c5f2bb3782e