### PR TITLE
Add team-level comparison to game summary

### DIFF
--- a/engine/generate_summary.py
+++ b/engine/generate_summary.py
@@ -1,4 +1,5 @@
 from typing import List, Dict
+from collections import defaultdict
 
 def generate_summary(events: List[Dict]) -> str:
     """
@@ -11,9 +12,9 @@ def generate_summary(events: List[Dict]) -> str:
         str: Simple text summary of the game.
     """
     goals_by_period = {
-      "regulation": sum(1 for event in events if event["event_type"] in ["goal"] and event["period"] in [1, 2, 3]),
-      "overtime": sum(1 for event in events if event["event_type"] in ["goal"] and event["period"] == 4),
-      "shootout": sum(1 for event in events if event["event_type"] in ["goal"] and event["period"] == 5),
+      "regulation": sum(1 for event in events if event["event_type"] == "goal" and event["period"] in [1, 2, 3]),
+      "overtime": sum(1 for event in events if event["event_type"] == "goal" and event["period"] == 4),
+      "shootout": sum(1 for event in events if event["event_type"] == "goal" and event["period"] == 5),
     }
 
     goal_count = goals_by_period["regulation"] + goals_by_period["overtime"] + goals_by_period["shootout"]
@@ -35,7 +36,45 @@ def generate_summary(events: List[Dict]) -> str:
     takeaway_count = sum(1 for event in events if event["event_type"] == "takeaway")
     delayed_penalty_count = sum(1 for event in events if event["event_type"] == "delayed-penalty")
 
-    return (
+    # Breakdown by team
+    stat_keys = {
+        "goal": "goals",
+        "shot-on-goal": "shots_on_goal",
+        "penalty": "penalties",
+        "hit": "hits",
+        "faceoff": "faceoffs",
+        "blocked-shot": "blocked_shots",
+        "missed-shot": "missed_shots",
+        "giveaway": "giveaways",
+        "takeaway": "takeaways",
+        "delayed-penalty": "delayed_penalties",
+    }
+
+    team_stats = defaultdict(lambda: {
+        "goals": 0,
+        "shots_on_goal": 0,
+        "penalties": 0,
+        "hits": 0,
+        "faceoffs": 0,
+        "blocked_shots": 0,
+        "missed_shots": 0,
+        "giveaways": 0,
+        "takeaways": 0,
+        "delayed_penalties": 0,
+    })
+
+    for event in events:
+        team_id = event.get("team_id")
+        if team_id is None:
+            continue
+        key = stat_keys.get(event["event_type"])
+        if key is None:
+            continue
+        team_stats[team_id][key] += 1
+        if event["event_type"] == "goal":
+            team_stats[team_id]["shots_on_goal"] += 1
+
+    summary = (
         f"Game Summary:\n"
         f"- Goals scored: {goal_count} (Reg: {goals_by_period['regulation']}, OT: {goals_by_period['overtime']}, SO: {goals_by_period['shootout']})\n"
         f"- Shots on goal: {sog_count} (Reg: {shots_by_period['regulation']}, OT: {shots_by_period['overtime']}, SO excluded)\n"
@@ -48,3 +87,40 @@ def generate_summary(events: List[Dict]) -> str:
         f"- Takeaways: {takeaway_count}\n"
         f"- Delayed penalties: {delayed_penalty_count}\n"
     )
+
+    teams = sorted(team_stats.keys())
+    if teams:
+        if len(teams) == 2:
+            t1, t2 = teams
+            summary += (
+                "Team Comparison:\n"
+                f"- Goals: {team_stats[t1]['goals']} - {team_stats[t2]['goals']}\n"
+                f"- Shots on goal: {team_stats[t1]['shots_on_goal']} - {team_stats[t2]['shots_on_goal']}\n"
+                f"- Penalties: {team_stats[t1]['penalties']} - {team_stats[t2]['penalties']}\n"
+                f"- Hits: {team_stats[t1]['hits']} - {team_stats[t2]['hits']}\n"
+                f"- Faceoffs: {team_stats[t1]['faceoffs']} - {team_stats[t2]['faceoffs']}\n"
+                f"- Blocked shots: {team_stats[t1]['blocked_shots']} - {team_stats[t2]['blocked_shots']}\n"
+                f"- Missed shots: {team_stats[t1]['missed_shots']} - {team_stats[t2]['missed_shots']}\n"
+                f"- Giveaways: {team_stats[t1]['giveaways']} - {team_stats[t2]['giveaways']}\n"
+                f"- Takeaways: {team_stats[t1]['takeaways']} - {team_stats[t2]['takeaways']}\n"
+                f"- Delayed penalties: {team_stats[t1]['delayed_penalties']} - {team_stats[t2]['delayed_penalties']}\n"
+            )
+        else:
+            summary += "Team Breakdown:\n"
+            for team in teams:
+                stats = team_stats[team]
+                summary += (
+                    f"Team {team}:\n"
+                    f"  Goals: {stats['goals']}\n"
+                    f"  Shots on goal: {stats['shots_on_goal']}\n"
+                    f"  Penalties: {stats['penalties']}\n"
+                    f"  Hits: {stats['hits']}\n"
+                    f"  Faceoffs: {stats['faceoffs']}\n"
+                    f"  Blocked shots: {stats['blocked_shots']}\n"
+                    f"  Missed shots: {stats['missed_shots']}\n"
+                    f"  Giveaways: {stats['giveaways']}\n"
+                    f"  Takeaways: {stats['takeaways']}\n"
+                    f"  Delayed penalties: {stats['delayed_penalties']}\n"
+                )
+
+    return summary

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,0 +1,19 @@
+from engine.generate_summary import generate_summary
+
+
+def test_generate_summary_team_breakdown():
+    events = [
+        {"event_type": "goal", "period": 1, "team_id": 1},
+        {"event_type": "shot-on-goal", "period": 1, "team_id": 2},
+        {"event_type": "penalty", "period": 2, "team_id": 1},
+        {"event_type": "hit", "period": 2, "team_id": 2},
+    ]
+
+    summary = generate_summary(events)
+
+    assert "Team Comparison" in summary
+    assert "- Goals: 1 - 0" in summary
+    assert "- Shots on goal: 1 - 1" in summary
+    assert "- Penalties: 1 - 0" in summary
+    assert "- Hits: 0 - 1" in summary
+


### PR DESCRIPTION
## Summary
- enhance `generate_summary` to track event counts per team and append a side-by-side team comparison section
- add unit test for team breakdown in summaries

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689621d66818832bbe15d6420bc2e734