### PR TITLE
Extend game summary with player highlights

### DIFF
--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -17,3 +17,22 @@ def test_generate_summary_team_breakdown():
     assert "- Penalties: 1 - 0" in summary
     assert "- Hits: 0 - 1" in summary
 
+
+def test_generate_summary_player_info():
+    events = [
+        {"event_type": "goal", "period": 1, "team_id": 1, "players": {"scorer_id": 101, "assist_ids": [102, 103]}},
+        {"event_type": "goal", "period": 2, "team_id": 2, "players": {"scorer_id": 201, "assist_ids": []}},
+        {"event_type": "goal", "period": 3, "team_id": 1, "players": {"scorer_id": 101, "assist_ids": [104]}},
+        {"event_type": "star", "star": 1, "players": {"player_id": 101}},
+        {"event_type": "star", "star": 2, "players": {"player_id": 201}},
+        {"event_type": "star", "star": 3, "players": {"player_id": 102}},
+    ]
+
+    summary = generate_summary(events)
+
+    assert "3 Stars of the Game" in summary
+    assert "- Star 1: Player 101" in summary
+    assert "Game-winning goal: Player 101" in summary
+    assert "Top goal scorers (2): Player 101" in summary
+    assert "Top point scorers (2): Player 101" in summary
+


### PR DESCRIPTION
## Summary
- capture three stars of the game
- determine game-winning goal scorer
- list top goal and point scorers
- add tests for player information in summaries

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689624d6d4c0832bafab16a9519cea67