### PR TITLE
Integrate game story data for three-star summaries

### DIFF
--- a/data_fetch/game_story.py
+++ b/data_fetch/game_story.py
@@ -1,0 +1,15 @@
+from nhlpy import NHLClient
+from typing import Dict, Any
+
+client = NHLClient()
+
+def get_game_story(game_id: int) -> Dict[str, Any]:
+    """Fetch the game story data for a specific NHL game.
+
+    Args:
+        game_id (int): Unique identifier for the game.
+
+    Returns:
+        Dict[str, Any]: Dictionary containing game story data, including three stars.
+    """
+    return client.game_center.game_story(game_id=game_id)

--- a/engine/generate_summary.py
+++ b/engine/generate_summary.py
@@ -140,14 +140,23 @@ def generate_summary(events: List[Dict]) -> str:
                     assists_by_player[assist] += 1
         elif event["event_type"] == "star":
             star_rank = event.get("star")
-            player_id = event.get("players", {}).get("player_id")
+            player_info = event.get("players", {})
+            player_id = player_info.get("player_id")
             if star_rank is not None and player_id is not None:
-                stars[star_rank] = player_id
+                stars[star_rank] = {
+                    "id": player_id,
+                    "name": player_info.get("name"),
+                }
 
     if stars:
         summary += "3 Stars of the Game:\n"
         for rank in sorted(stars.keys()):
-            summary += f"- Star {rank}: Player {stars[rank]}\n"
+            player = stars[rank]
+            name = player.get("name")
+            if name:
+                summary += f"- Star {rank}: {name}\n"
+            else:
+                summary += f"- Star {rank}: Player {player['id']}\n"
 
     # Determine game-winning goal
     gwg = None

--- a/engine/process_game.py
+++ b/engine/process_game.py
@@ -1,8 +1,31 @@
 from data_fetch.play_by_play import get_play_by_play
+from data_fetch.game_story import get_game_story
 from engine.transform import transform_event
 from typing import List, Dict, Any
+
 
 def process_game_events(game_id: int) -> List[Dict[str, Any]]:
     raw_data = get_play_by_play(game_id)
     events = raw_data.get("plays", [])
-    return [transform_event(e) for e in events]
+
+    roster_spots = raw_data.get("rosterSpots", [])
+    player_map = {
+        spot.get("playerId"): f"{spot.get('firstName', {}).get('default', '')} {spot.get('lastName', {}).get('default', '')}".strip()
+        for spot in roster_spots
+    }
+
+    transformed_events = [transform_event(e) for e in events]
+
+    story = get_game_story(game_id)
+    stars = story.get("summary", {}).get("threeStars", [])
+    for star in stars:
+        pid = star.get("playerId")
+        transformed_events.append(
+            {
+                "event_type": "star",
+                "star": star.get("star"),
+                "players": {"player_id": pid, "name": player_map.get(pid)},
+            }
+        )
+
+    return transformed_events

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,3 +1,6 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from engine.generate_summary import generate_summary
 
 
@@ -23,7 +26,7 @@ def test_generate_summary_player_info():
         {"event_type": "goal", "period": 1, "team_id": 1, "players": {"scorer_id": 101, "assist_ids": [102, 103]}},
         {"event_type": "goal", "period": 2, "team_id": 2, "players": {"scorer_id": 201, "assist_ids": []}},
         {"event_type": "goal", "period": 3, "team_id": 1, "players": {"scorer_id": 101, "assist_ids": [104]}},
-        {"event_type": "star", "star": 1, "players": {"player_id": 101}},
+        {"event_type": "star", "star": 1, "players": {"player_id": 101, "name": "Player One"}},
         {"event_type": "star", "star": 2, "players": {"player_id": 201}},
         {"event_type": "star", "star": 3, "players": {"player_id": 102}},
     ]
@@ -31,7 +34,8 @@ def test_generate_summary_player_info():
     summary = generate_summary(events)
 
     assert "3 Stars of the Game" in summary
-    assert "- Star 1: Player 101" in summary
+    assert "- Star 1: Player One" in summary
+    assert "- Star 2: Player 201" in summary
     assert "Game-winning goal: Player 101" in summary
     assert "Top goal scorers (2): Player 101" in summary
     assert "Top point scorers (2): Player 101" in summary

--- a/tests/test_process_game.py
+++ b/tests/test_process_game.py
@@ -1,0 +1,32 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import types
+
+fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
+sys.modules['nhlpy'] = fake_nhlpy
+
+from engine.process_game import process_game_events
+
+
+def test_process_game_events_adds_three_stars(monkeypatch):
+    def fake_get_play_by_play(game_id):
+        return {
+            "plays": [],
+            "rosterSpots": [
+                {
+                    "playerId": 1,
+                    "firstName": {"default": "John"},
+                    "lastName": {"default": "Doe"},
+                }
+            ],
+        }
+
+    def fake_get_game_story(game_id):
+        return {"summary": {"threeStars": [{"star": 1, "playerId": 1}]}}
+
+    monkeypatch.setattr("engine.process_game.get_play_by_play", fake_get_play_by_play)
+    monkeypatch.setattr("engine.process_game.get_game_story", fake_get_game_story)
+
+    events = process_game_events(123)
+    assert {"event_type": "star", "star": 1, "players": {"player_id": 1, "name": "John Doe"}} in events

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,3 +1,6 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 import pytest
 
 from engine.transform import transform_event


### PR DESCRIPTION
## Summary
- add `game_story` data fetch module for three-star information
- include three stars and player names when processing game events
- show star player names in generated summaries
- test three-star integration and update existing tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68962e1c996c832bbc310c8fc35a91c7