### PR TITLE
Integrate game story data for three-star summaries

### DIFF
--- a/data_fetch/game_story.py
+++ b/data_fetch/game_story.py
@@ -1,0 +1,15 @@
+from nhlpy import NHLClient
+from typing import Dict, Any
+
+client = NHLClient()
+
+def get_game_story(game_id: int) -> Dict[str, Any]:
+    """Fetch the game story data for a specific NHL game.
+
+    Args:
+        game_id (int): Unique identifier for the game.
+
+    Returns:
+        Dict[str, Any]: Dictionary containing game story data, including three stars.
+    """
+    return client.game_center.game_story(game_id=game_id)

--- a/engine/process_game.py
+++ b/engine/process_game.py
@@ -1,8 +1,40 @@
 from data_fetch.play_by_play import get_play_by_play
+from data_fetch.game_story import get_game_story
 from engine.transform import transform_event
 from typing import List, Dict, Any
+
 
 def process_game_events(game_id: int) -> List[Dict[str, Any]]:
     raw_data = get_play_by_play(game_id)
     events = raw_data.get("plays", [])
-    return [transform_event(e) for e in events]
+
+    roster_spots = raw_data.get("rosterSpots", [])
+    player_map = {
+        spot.get("playerId"): f"{spot.get('firstName', {}).get('default', '')} {spot.get('lastName', {}).get('default', '')}".strip()
+        for spot in roster_spots
+    }
+
+    transformed_events = [transform_event(e) for e in events]
+
+    for event in transformed_events:
+        if event.get("event_type") == "goal":
+            players = event.get("players", {})
+            scorer_id = players.get("scorer_id")
+            if scorer_id is not None:
+                players["scorer_name"] = player_map.get(scorer_id)
+            assist_ids = players.get("assist_ids", [])
+            players["assist_names"] = [player_map.get(aid) for aid in assist_ids]
+
+    story = get_game_story(game_id)
+    stars = story.get("summary", {}).get("threeStars", [])
+    for star in stars:
+        pid = star.get("playerId")
+        transformed_events.append(
+            {
+                "event_type": "star",
+                "star": star.get("star"),
+                "players": {"player_id": pid, "name": player_map.get(pid)},
+            }
+        )
+
+    return transformed_events

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,3 +1,6 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from engine.generate_summary import generate_summary
 
 
@@ -20,10 +23,35 @@ def test_generate_summary_team_breakdown():
 
 def test_generate_summary_player_info():
     events = [
-        {"event_type": "goal", "period": 1, "team_id": 1, "players": {"scorer_id": 101, "assist_ids": [102, 103]}},
-        {"event_type": "goal", "period": 2, "team_id": 2, "players": {"scorer_id": 201, "assist_ids": []}},
-        {"event_type": "goal", "period": 3, "team_id": 1, "players": {"scorer_id": 101, "assist_ids": [104]}},
-        {"event_type": "star", "star": 1, "players": {"player_id": 101}},
+        {
+            "event_type": "goal",
+            "period": 1,
+            "team_id": 1,
+            "players": {
+                "scorer_id": 101,
+                "scorer_name": "Player One",
+                "assist_ids": [102, 103],
+                "assist_names": ["Assist Two", "Assist Three"],
+            },
+        },
+        {
+            "event_type": "goal",
+            "period": 2,
+            "team_id": 2,
+            "players": {"scorer_id": 201, "scorer_name": "Player Two", "assist_ids": []},
+        },
+        {
+            "event_type": "goal",
+            "period": 3,
+            "team_id": 1,
+            "players": {
+                "scorer_id": 101,
+                "scorer_name": "Player One",
+                "assist_ids": [104],
+                "assist_names": ["Assist Four"],
+            },
+        },
+        {"event_type": "star", "star": 1, "players": {"player_id": 101, "name": "Player One"}},
         {"event_type": "star", "star": 2, "players": {"player_id": 201}},
         {"event_type": "star", "star": 3, "players": {"player_id": 102}},
     ]
@@ -31,8 +59,9 @@ def test_generate_summary_player_info():
     summary = generate_summary(events)
 
     assert "3 Stars of the Game" in summary
-    assert "- Star 1: Player 101" in summary
-    assert "Game-winning goal: Player 101" in summary
-    assert "Top goal scorers (2): Player 101" in summary
-    assert "Top point scorers (2): Player 101" in summary
+    assert "- Star 1: Player One" in summary
+    assert "- Star 2: Player 201" in summary
+    assert "Game-winning goal: Player One" in summary
+    assert "Top goal scorers (2): Player One" in summary
+    assert "Top point scorers (2): Player One" in summary
 

--- a/tests/test_process_game.py
+++ b/tests/test_process_game.py
@@ -1,0 +1,69 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import types
+
+fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
+sys.modules['nhlpy'] = fake_nhlpy
+
+from engine.process_game import process_game_events
+
+
+def test_process_game_events_adds_three_stars(monkeypatch):
+    def fake_get_play_by_play(game_id):
+        return {
+            "plays": [],
+            "rosterSpots": [
+                {
+                    "playerId": 1,
+                    "firstName": {"default": "John"},
+                    "lastName": {"default": "Doe"},
+                }
+            ],
+        }
+
+    def fake_get_game_story(game_id):
+        return {"summary": {"threeStars": [{"star": 1, "playerId": 1}]}}
+
+    monkeypatch.setattr("engine.process_game.get_play_by_play", fake_get_play_by_play)
+    monkeypatch.setattr("engine.process_game.get_game_story", fake_get_game_story)
+
+    events = process_game_events(123)
+    assert {"event_type": "star", "star": 1, "players": {"player_id": 1, "name": "John Doe"}} in events
+
+
+def test_process_game_events_adds_goal_names(monkeypatch):
+    def fake_get_play_by_play(game_id):
+        return {
+            "plays": [
+                {
+                    "typeDescKey": "goal",
+                    "details": {
+                        "scoringPlayerId": 1,
+                        "assist1PlayerId": 2,
+                        "assist2PlayerId": 3,
+                        "goalieInNetId": 4,
+                        "eventOwnerTeamId": 5,
+                    },
+                    "periodDescriptor": {"number": 1},
+                    "timeInPeriod": "10:00",
+                }
+            ],
+            "rosterSpots": [
+                {"playerId": 1, "firstName": {"default": "John"}, "lastName": {"default": "Doe"}},
+                {"playerId": 2, "firstName": {"default": "Jane"}, "lastName": {"default": "Smith"}},
+                {"playerId": 3, "firstName": {"default": "Bob"}, "lastName": {"default": "Jones"}},
+            ],
+        }
+
+    def fake_get_game_story(game_id):
+        return {"summary": {"threeStars": []}}
+
+    monkeypatch.setattr("engine.process_game.get_play_by_play", fake_get_play_by_play)
+    monkeypatch.setattr("engine.process_game.get_game_story", fake_get_game_story)
+
+    events = process_game_events(456)
+    goal_event = events[0]
+    players = goal_event["players"]
+    assert players["scorer_name"] == "John Doe"
+    assert players["assist_names"] == ["Jane Smith", "Bob Jones"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,3 +1,6 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 import pytest
 
 from engine.transform import transform_event


### PR DESCRIPTION
## Summary
- add `game_story` data fetch module for three-star information
- include three stars and player names when processing game events
- show star player names in generated summaries
- test three-star integration and update existing tests
- map roster player names so summaries list goal and point leaders by name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68962e1c996c832bbc310c8fc35a91c7