### PR TITLE
Add game selection and team-aware summaries

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,32 +5,47 @@ from models import GameSchedule
 import os
 import json
 
-DATE = "2025-04-01"  # or today's date if you're sure games exist
+DATE = "2025-04-01"  # Fallback date if user input is empty
 
 def main():
     output_dir = "data/events"
     os.makedirs(output_dir, exist_ok=True)
 
-    schedule = get_schedule(DATE)
+    date = input("Enter game date (YYYY-MM-DD): ").strip() or DATE
+    schedule = get_schedule(date)
 
-    for game in schedule:
-        print(f"Processing Game ID: {game.game_id} ({game.home_team} vs {game.away_team})")
-        try:
-            events = process_game_events(game.game_id)
-            if events:
-                with open(f"{output_dir}/{game.game_id}.jsonl", "w") as f:
-                    for event in events:
-                        json.dump(event, f)
-                        f.write("\n")
-                print(f"✅ Saved events for game {game.game_id}")
+    if not schedule:
+        print("No games scheduled for this date.")
+        return
 
-                summary = generate_summary(events)
-                print(summary)
+    print("Available games:")
+    for idx, game in enumerate(schedule, start=1):
+        print(f"{idx}. {game.away_team} at {game.home_team} (ID: {game.game_id})")
 
-            else:
-                print(f"⚠️ No events for game {game.game_id}")
-        except Exception as e:
-            print(f"❌ Failed to process game {game.game_id}: {e}")
+    selection = input("Select a game number: ").strip()
+    try:
+        game = schedule[int(selection) - 1]
+    except (ValueError, IndexError):
+        print("Invalid selection.")
+        return
+
+    print(f"Processing Game ID: {game.game_id} ({game.home_team} vs {game.away_team})")
+    try:
+        events = process_game_events(game.game_id)
+        if events:
+            with open(f"{output_dir}/{game.game_id}.jsonl", "w") as f:
+                for event in events:
+                    json.dump(event, f)
+                    f.write("\n")
+            print(f"✅ Saved events for game {game.game_id}")
+
+            summary = generate_summary(events)
+            print(summary)
+
+        else:
+            print(f"⚠️ No events for game {game.game_id}")
+    except Exception as e:
+        print(f"❌ Failed to process game {game.game_id}: {e}")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -27,6 +27,7 @@ def test_generate_summary_player_info():
             "event_type": "goal",
             "period": 1,
             "team_id": 1,
+            "team_name": "Team 1",
             "players": {
                 "scorer_id": 101,
                 "scorer_name": "Player One",
@@ -38,12 +39,14 @@ def test_generate_summary_player_info():
             "event_type": "goal",
             "period": 2,
             "team_id": 2,
+            "team_name": "Team 2",
             "players": {"scorer_id": 201, "scorer_name": "Player Two", "assist_ids": []},
         },
         {
             "event_type": "goal",
             "period": 3,
             "team_id": 1,
+            "team_name": "Team 1",
             "players": {
                 "scorer_id": 101,
                 "scorer_name": "Player One",
@@ -60,9 +63,10 @@ def test_generate_summary_player_info():
     summary = generate_summary(events)
 
     assert "3 Stars of the Game" in summary
-    assert "- Star 1: Player One" in summary
-    assert "- Star 2: Player 201" in summary
-    assert "Game-winning goal: Player One" in summary
-    assert "Top goal scorers (2): Player One" in summary
-    assert "Top point scorers (2): Player One" in summary
+    assert "- Star 1: Player One (Team 1)" in summary
+    assert "- Star 2: Player Two (Team 2)" in summary
+    assert "- Star 3: Assist Two (Team 1)" in summary
+    assert "Game-winning goal: Player One (Team 1)" in summary
+    assert "Top goal scorers (2): Player One (Team 1)" in summary
+    assert "Top point scorers (2): Player One (Team 1)" in summary
 


### PR DESCRIPTION
## Summary
- Allow users to input a date and select a specific game to process
- Include player team abbreviations in stars, game-winning goal, and scoring summaries
- Update tests for new summary output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896332c1508832b8d3e8cfe58d7d1f2