### PR TITLE
Add team name mapping and star stats to summaries

### DIFF
--- a/engine/generate_summary.py
+++ b/engine/generate_summary.py
@@ -167,6 +167,8 @@ def generate_summary(events: List[Dict]) -> str:
                 stars[star_rank] = {
                     "id": player_id,
                     "name": player_info.get("name"),
+                    "position": player_info.get("position"),
+                    "stats": player_info.get("stats", {}),
                 }
                 if player_info.get("name"):
                     player_names[player_id] = player_info.get("name")
@@ -185,7 +187,26 @@ def generate_summary(events: List[Dict]) -> str:
         summary += "3 Stars of the Game:\n"
         for rank in sorted(stars.keys()):
             player = stars[rank]
-            summary += f"- Star {rank}: {format_player(player['id'])}\n"
+            line = f"- Star {rank}: {format_player(player['id'])}"
+            if player.get("position"):
+                line += f" ({player['position']})"
+            stats = player.get("stats") or {}
+            stat_parts = []
+            if "goalsAgainstAverage" in stats or "savePctg" in stats:
+                if "goalsAgainstAverage" in stats:
+                    stat_parts.append(f"GAA: {stats['goalsAgainstAverage']}")
+                if "savePctg" in stats:
+                    stat_parts.append(f"SV%: {stats['savePctg']}")
+            else:
+                if "goals" in stats:
+                    stat_parts.append(f"Goals: {stats['goals']}")
+                if "assists" in stats:
+                    stat_parts.append(f"Assists: {stats['assists']}")
+                if "points" in stats:
+                    stat_parts.append(f"Points: {stats['points']}")
+            if stat_parts:
+                line += " - " + ", ".join(stat_parts)
+            summary += line + "\n"
 
     # Determine game-winning goal
     gwg = None

--- a/engine/process_game.py
+++ b/engine/process_game.py
@@ -9,14 +9,38 @@ def process_game_events(game_id: int) -> List[Dict[str, Any]]:
     events = raw_data.get("plays", [])
 
     roster_spots = raw_data.get("rosterSpots", [])
-    player_map = {
-        spot.get("playerId"): f"{spot.get('firstName', {}).get('default', '')} {spot.get('lastName', {}).get('default', '')}".strip()
-        for spot in roster_spots
-    }
+    player_map: Dict[int, str] = {}
+    player_team_map: Dict[int, int] = {}
+    for spot in roster_spots:
+        pid = spot.get("playerId")
+        player_map[pid] = f"{spot.get('firstName', {}).get('default', '')} {spot.get('lastName', {}).get('default', '')}".strip()
+        player_team_map[pid] = spot.get("teamId")
+
+    team_name_map: Dict[int, str] = {}
+    abbrev_to_id: Dict[str, int] = {}
+    for side in ["homeTeam", "awayTeam"]:
+        team = raw_data.get(side, {}) or {}
+        tid = team.get("id")
+        if tid is None:
+            continue
+        name = (
+            (team.get("name") or {}).get("default")
+            or (team.get("commonName") or {}).get("default")
+            or team.get("abbrev")
+            or f"Team {tid}"
+        )
+        team_name_map[tid] = name
+        abbrev = team.get("abbrev")
+        if abbrev:
+            abbrev_to_id[abbrev] = tid
 
     transformed_events = [transform_event(e) for e in events]
 
     for event in transformed_events:
+        team_id = event.get("team_id")
+        if team_id in team_name_map:
+            event["team_name"] = team_name_map[team_id]
+
         if event.get("event_type") == "goal":
             players = event.get("players", {})
             scorer_id = players.get("scorer_id")
@@ -26,14 +50,40 @@ def process_game_events(game_id: int) -> List[Dict[str, Any]]:
             players["assist_names"] = [player_map.get(aid) for aid in assist_ids]
 
     story = get_game_story(game_id)
+    for side in ["homeTeam", "awayTeam"]:
+        team = story.get(side, {}) or {}
+        tid = team.get("id")
+        if tid and tid not in team_name_map:
+            name = (
+                (team.get("name") or {}).get("default")
+                or (team.get("commonName") or {}).get("default")
+                or team.get("abbrev")
+                or f"Team {tid}"
+            )
+            team_name_map[tid] = name
+
     stars = story.get("summary", {}).get("threeStars", [])
     for star in stars:
         pid = star.get("playerId")
+        team_id = player_team_map.get(pid) or abbrev_to_id.get(star.get("teamAbbrev"))
+        stats = {
+            key: star.get(key)
+            for key in ["goalsAgainstAverage", "savePctg", "goals", "assists", "points"]
+            if star.get(key) is not None
+        }
         transformed_events.append(
             {
                 "event_type": "star",
                 "star": star.get("star"),
-                "players": {"player_id": pid, "name": player_map.get(pid)},
+                "team_id": team_id,
+                "team_name": team_name_map.get(team_id),
+                "players": {
+                    "player_id": pid,
+                    "name": player_map.get(pid),
+                    "team_id": team_id,
+                    "position": star.get("position"),
+                    "stats": stats,
+                },
             }
         )
 

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -27,7 +27,7 @@ def test_generate_summary_player_info():
             "event_type": "goal",
             "period": 1,
             "team_id": 1,
-            "team_name": "Team 1",
+            "team_name": "Flyers",
             "players": {
                 "scorer_id": 101,
                 "scorer_name": "Player One",
@@ -39,14 +39,14 @@ def test_generate_summary_player_info():
             "event_type": "goal",
             "period": 2,
             "team_id": 2,
-            "team_name": "Team 2",
+            "team_name": "Penguins",
             "players": {"scorer_id": 201, "scorer_name": "Player Two", "assist_ids": []},
         },
         {
             "event_type": "goal",
             "period": 3,
             "team_id": 1,
-            "team_name": "Team 1",
+            "team_name": "Flyers",
             "players": {
                 "scorer_id": 101,
                 "scorer_name": "Player One",
@@ -55,18 +55,54 @@ def test_generate_summary_player_info():
             },
         },
 
-        {"event_type": "star", "star": 1, "players": {"player_id": 101, "name": "Player One"}},
-        {"event_type": "star", "star": 2, "players": {"player_id": 201}},
-        {"event_type": "star", "star": 3, "players": {"player_id": 102}},
+        {
+            "event_type": "star",
+            "star": 1,
+            "team_id": 1,
+            "team_name": "Flyers",
+            "players": {
+                "player_id": 101,
+                "name": "Player One",
+                "team_id": 1,
+                "position": "C",
+                "stats": {"goals": 2, "assists": 0, "points": 2},
+            },
+        },
+        {
+            "event_type": "star",
+            "star": 2,
+            "team_id": 2,
+            "team_name": "Penguins",
+            "players": {
+                "player_id": 201,
+                "name": "Player Two",
+                "team_id": 2,
+                "position": "G",
+                "stats": {"goalsAgainstAverage": 1.0, "savePctg": 0.95},
+            },
+        },
+        {
+            "event_type": "star",
+            "star": 3,
+            "team_id": 1,
+            "team_name": "Flyers",
+            "players": {
+                "player_id": 102,
+                "name": "Assist Two",
+                "team_id": 1,
+                "position": "D",
+                "stats": {"goals": 0, "assists": 1, "points": 1},
+            },
+        },
     ]
 
     summary = generate_summary(events)
 
     assert "3 Stars of the Game" in summary
-    assert "- Star 1: Player One (Team 1)" in summary
-    assert "- Star 2: Player Two (Team 2)" in summary
-    assert "- Star 3: Assist Two (Team 1)" in summary
-    assert "Game-winning goal: Player One (Team 1)" in summary
-    assert "Top goal scorers (2): Player One (Team 1)" in summary
-    assert "Top point scorers (2): Player One (Team 1)" in summary
+    assert "- Star 1: Player One (Flyers) (C) - Goals: 2, Assists: 0, Points: 2" in summary
+    assert "- Star 2: Player Two (Penguins) (G) - GAA: 1.0, SV%: 0.95" in summary
+    assert "- Star 3: Assist Two (Flyers) (D) - Goals: 0, Assists: 1, Points: 1" in summary
+    assert "Game-winning goal: Player One (Flyers)" in summary
+    assert "Top goal scorers (2): Player One (Flyers)" in summary
+    assert "Top point scorers (2): Player One (Flyers)" in summary
 


### PR DESCRIPTION
## Summary
- Map team IDs to proper team names using play-by-play and game story data
- Attach team, position, and performance stats to three-star events
- Display position and key stats for stars in generated summaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896378a466c832b88bae41b61fbcdc1