### PR TITLE
Add AI-based game summary generation using templates

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,3 +1,7 @@
 """Core engine modules for processing NHL events."""
 
-__all__ = ["transform_event"]
+from .transform import transform_event
+from .generate_summary import generate_summary
+from .ai_summary import generate_ai_summary
+
+__all__ = ["transform_event", "generate_summary", "generate_ai_summary"]

--- a/engine/ai_summary.py
+++ b/engine/ai_summary.py
@@ -1,0 +1,41 @@
+"""Generate an AI-powered game summary using OpenAI's ChatCompletion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+import openai
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+
+def _load_template(name: str) -> str:
+    """Load a text template from the prompts directory."""
+    path = TEMPLATE_DIR / name
+    return path.read_text(encoding="utf-8")
+
+
+def generate_ai_summary(events: List[Dict]) -> str:
+    """Generate a natural language summary for a game.
+
+    Args:
+        events (List[Dict]): Structured event data for the game.
+
+    Returns:
+        str: Summary produced by the AI model.
+    """
+    template = _load_template("game_summary.txt")
+    populated = template.format(events=json.dumps(events, indent=2))
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": populated}],
+    )
+
+    return response["choices"][0]["message"]["content"].strip()
+
+
+__all__ = ["generate_ai_summary"]

--- a/prompts/game_summary.txt
+++ b/prompts/game_summary.txt
@@ -1,0 +1,7 @@
+You are an expert NHL commentator. Using the structured events below, write a concise and engaging summary of the game.
+
+Events:
+{events}
+
+Summary:
+

--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -1,0 +1,21 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import openai
+from engine.ai_summary import generate_ai_summary
+
+
+def test_generate_ai_summary_includes_events(monkeypatch):
+    events = [{"event_type": "goal", "team_name": "Flyers", "period": 1}]
+    expected = "Summary text"
+
+    def fake_create(*args, **kwargs):
+        assert "messages" in kwargs
+        content = "\n".join(m["content"] for m in kwargs["messages"])
+        assert "goal" in content
+        return {"choices": [{"message": {"content": expected}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    summary = generate_ai_summary(events)
+    assert summary == expected


### PR DESCRIPTION
## Summary
- add prompts/game_summary.txt template for AI-generated summaries
- implement `generate_ai_summary` using OpenAI ChatCompletion and template population
- expose `generate_ai_summary` via engine package and test for event injection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68976294d7bc832b8eee7eb997409aed