### PR TITLE
docs: complete setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ NHL_API_BASE=https://api.nhle.com/stats/rest/
 ```bash
 pip install -r requirements.txt
 ```
+
+## 🚀 Usage
+
+Run the CLI to summarize a game:
+
+```bash
+python main.py
+```
+
+Follow the prompts to choose a game and select between AI or rule-based summaries.
+
+## 🤝 Contributing
+
+Contributions are welcome! Please fork the repository, create a feature branch, and open a pull request.
+Feel free to submit issues for bugs or feature suggestions.
+


### PR DESCRIPTION
## Summary
- close README install block and add CLI usage instructions
- provide contribution guidelines

## Testing
- `python -m markdown README.md` *(fails: No module named markdown)*
- `pip install markdown` *(fails: 403 ProxyError)*
- `pytest` *(fails: OpenAIError: api_key must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689faae02148832ba4ab6a9cce5a38ac