### PR TITLE
Update AI summary test for responses API

### DIFF
--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -2,6 +2,11 @@ import sys, os
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import openai
+from openai.resources.responses import Responses
+
+# Ensure OpenAI client can be instantiated during tests
+os.environ["OPENAI_API_KEY"] = "test"
+
 from engine.ai_summary import generate_ai_summary
 
 
@@ -9,13 +14,16 @@ def test_generate_ai_summary_includes_events(monkeypatch):
     events = [{"event_type": "goal", "team_name": "Flyers", "period": 1}]
     expected = "Summary text"
 
-    def fake_create(*args, **kwargs):
-        assert "messages" in kwargs
-        content = "\n".join(m["content"] for m in kwargs["messages"])
-        assert "goal" in content
-        return {"choices": [{"message": {"content": expected}}]}
+    def fake_create(self, *args, **kwargs):
+        assert "input" in kwargs
+        assert "goal" in kwargs["input"]
 
-    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+        class Response:
+            output_text = expected
+
+        return Response()
+
+    monkeypatch.setattr(Responses, "create", fake_create)
 
     summary = generate_ai_summary(events)
     assert summary == expected


### PR DESCRIPTION
## Summary
- Adjust AI summary unit test to mock `openai.OpenAI.responses.create`
- Verify events embedded in input and check `response.output_text`

## Testing
- `pytest tests/test_ai_summary.py -q`
- `pytest -q` *(fails: test_generate_summary_team_breakdown, test_generate_summary_player_info, test_summarize_game_ai)*

------
https://chatgpt.com/codex/tasks/task_e_689fab00c0b0832b8d191d44581989ba