### PR TITLE
refactor: remove path hacks from tests

### DIFF
--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -1,6 +1,3 @@
-import sys, os
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 import openai
 from engine.ai_summary import generate_ai_summary
 

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,6 +1,3 @@
-import sys, os
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from engine.generate_summary import generate_summary
 
 

--- a/tests/test_process_game.py
+++ b/tests/test_process_game.py
@@ -1,6 +1,4 @@
-import sys, os
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
+import sys
 import types
 
 fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())

--- a/tests/test_summarize_game.py
+++ b/tests/test_summarize_game.py
@@ -1,6 +1,3 @@
-import sys, os
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from engine.summarize_game import summarize_game
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,6 +1,3 @@
-import sys, os
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 import pytest
 
 from engine.transform import transform_event


### PR DESCRIPTION
## Summary
- refactor tests to import project modules directly without modifying sys.path

## Testing
- `OPENAI_API_KEY=dummy python -m pytest -q` *(fails: APIConnectionError, AssertionError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_689fab2707e4832b83efe7d0904a27fe