### PR TITLE
Support game story in AI summary

### DIFF
--- a/engine/ai_summary.py
+++ b/engine/ai_summary.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict
 from dotenv import load_dotenv
 from os import getenv
 from openai import OpenAI
@@ -23,17 +23,22 @@ def _load_template(name: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def generate_ai_summary(events: List[Dict]) -> str:
+def generate_ai_summary(play_by_play: Dict, game_story: Dict) -> str:
     """Generate a natural language summary for a game.
 
     Args:
-        events (List[Dict]): Structured event data for the game.
+        play_by_play (Dict): Structured play-by-play event data for the game.
+        game_story (Dict): Additional narrative data for the game, including
+            stars and statistics.
 
     Returns:
         str: Summary produced by the AI model.
     """
     template = _load_template("game_summary.txt")
-    populated = template.format(events=json.dumps(events, indent=2))
+    populated = template.format(
+        play_by_play=json.dumps(play_by_play, indent=2),
+        game_story=json.dumps(game_story, indent=2),
+    )
 
     try:
         response = client.responses.create(

--- a/engine/summarize_game.py
+++ b/engine/summarize_game.py
@@ -3,7 +3,7 @@
 from .process_game import process_game_events
 from .ai_summary import generate_ai_summary
 from .generate_summary import generate_summary
-from data_fetch import get_play_by_play
+from data_fetch import get_play_by_play, get_game_story
 
 
 def summarize_game(game_id: int, use_ai: bool = True) -> str:
@@ -20,7 +20,10 @@ def summarize_game(game_id: int, use_ai: bool = True) -> str:
     """
     events = process_game_events(game_id)
     if use_ai:
-        return generate_ai_summary(get_play_by_play(game_id))
+        return generate_ai_summary(
+            get_play_by_play(game_id),
+            get_game_story(game_id),
+        )
     return generate_summary(events)
 
 

--- a/prompts/game_summary.txt
+++ b/prompts/game_summary.txt
@@ -1,12 +1,15 @@
-You are an expert NHL commentator, analytical, yet very entertaining. 
-Using the structured events below, write a concise and engaging summary of the game.
-Use the tone of voice similar to The Hockey Guy from YouTube. 
+You are an expert NHL commentator, analytical, yet very entertaining.
+Using the structured play-by-play and game story below, write a concise and engaging summary of the game.
+Use the tone of voice similar to The Hockey Guy from YouTube.
 
-At the end of the report, provide some key match statistics (overall score, shots, penalties) 
-and 3 starts of the game (with their respective stats). 
+At the end of the report, provide some key match statistics (overall score, shots, penalties)
+and 3 starts of the game (with their respective stats).
 
-Events:
-{events}
+Play-by-Play:
+{play_by_play}
+
+Game Story:
+{game_story}
 
 Summary:
 

--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -11,23 +11,27 @@ os.environ.setdefault("OPENAI_API_KEY", "test-key")
 import engine.ai_summary as ai_summary
 
 
-def test_generate_ai_summary_includes_events(monkeypatch):
-    events = [{"event_type": "goal", "team_name": "Flyers", "period": 1}]
+def test_generate_ai_summary_includes_payloads(monkeypatch):
+    play_by_play = {"events": [{"event_type": "goal", "team_name": "Flyers"}]}
+    game_story = {"stars": ["Player One"]}
     expected = "Summary text"
 
     def fake_create(*args, **kwargs):
-        assert "goal" in kwargs["input"]
+        input_payload = kwargs["input"]
+        assert "goal" in input_payload
+        assert "Player One" in input_payload
         return SimpleNamespace(output_text=expected)
 
     monkeypatch.setattr(ai_summary.client.responses, "create", fake_create)
 
 
-    summary = ai_summary.generate_ai_summary(events)
+    summary = ai_summary.generate_ai_summary(play_by_play, game_story)
     assert summary == expected
 
 
 def test_generate_ai_summary_handles_error(monkeypatch):
-    events = [{"event_type": "goal"}]
+    play_by_play = {"events": []}
+    game_story = {"stars": []}
 
     def fake_create(*args, **kwargs):
         raise Exception("boom")
@@ -35,7 +39,7 @@ def test_generate_ai_summary_handles_error(monkeypatch):
     monkeypatch.setattr(ai_summary.client.responses, "create", fake_create)
 
     with pytest.raises(RuntimeError, match="boom"):
-        ai_summary.generate_ai_summary(events)
+        ai_summary.generate_ai_summary(play_by_play, game_story)
 
 
 def test_missing_api_key(monkeypatch):

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -94,9 +94,9 @@ def test_generate_summary_player_info():
     summary = generate_summary(events)
 
     assert "3 Stars of the Game" in summary
-    assert "- Star 1: Player One (C) - Goals: 2, Assists: 0, Points: 2" in summary
-    assert "- Star 2: Player Two (G) - GAA: 1.0, SV%: 0.95" in summary
-    assert "- Star 3: Assist Two (D) - Goals: 0, Assists: 1, Points: 1" in summary
-    assert "Top goal scorers (2): Player One" in summary
-    assert "Top point scorers (2 pts): Player One" in summary
+    assert "- Star 1: Player One (Flyers) (C) - Goals: 2, Assists: 0, Points: 2" in summary
+    assert "- Star 2: Player Two (Penguins) (G) - GAA: 1.0, SV%: 0.95" in summary
+    assert "- Star 3: Assist Two (Flyers) (D) - Goals: 0, Assists: 1, Points: 1" in summary
+    assert "Top goal scorers (2): Player One (Flyers)" in summary
+    assert "Top point scorers (2 pts): Player One (Flyers)" in summary
 

--- a/tests/test_process_game.py
+++ b/tests/test_process_game.py
@@ -1,4 +1,4 @@
-import sys, os
+import sys, os, types
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")

--- a/tests/test_summarize_game.py
+++ b/tests/test_summarize_game.py
@@ -1,7 +1,10 @@
-import sys, os
+import sys, os, types
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
+sys.modules['nhlpy'] = fake_nhlpy
 
 from engine.summarize_game import summarize_game
 
@@ -15,7 +18,7 @@ def test_summarize_game_rule_based(monkeypatch):
         assert events == ["event"]
         return "rule summary"
 
-    def fake_generate_ai_summary(events):
+    def fake_generate_ai_summary(*args, **kwargs):
         raise AssertionError("AI summary should not be called")
 
     monkeypatch.setattr("engine.summarize_game.process_game_events", fake_process_game_events)
@@ -34,14 +37,16 @@ def test_summarize_game_ai(monkeypatch):
     def fake_generate_summary(events):
         raise AssertionError("Rule-based summary should not be called")
 
-    def fake_generate_ai_summary(events):
-        assert events == ["event"]
+    def fake_generate_ai_summary(play_by_play, game_story):
+        assert play_by_play == ["event"]
+        assert game_story == {"story": "data"}
         return "ai summary"
 
     monkeypatch.setattr("engine.summarize_game.process_game_events", fake_process_game_events)
     monkeypatch.setattr("engine.summarize_game.generate_summary", fake_generate_summary)
     monkeypatch.setattr("engine.summarize_game.generate_ai_summary", fake_generate_ai_summary)
     monkeypatch.setattr("engine.summarize_game.get_play_by_play", lambda game_id: ["event"])
+    monkeypatch.setattr("engine.summarize_game.get_game_story", lambda game_id: {"story": "data"})
 
     summary = summarize_game(2, use_ai=True)
     assert summary == "ai summary"


### PR DESCRIPTION
## Summary
- allow `generate_ai_summary` to combine play-by-play and game story data
- reference both inputs in `game_summary` prompt and wire into `summarize_game`
- update tests to supply new payloads and adjust expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fb0b14dc8832b8d5de98bdcf0b519