### PR TITLE
Fix typo in game summary prompt

### DIFF
--- a/prompts/game_summary.txt
+++ b/prompts/game_summary.txt
@@ -3,7 +3,7 @@ Using the structured play-by-play and game story below, write a concise and enga
 Use the tone of voice similar to The Hockey Guy from YouTube.
 
 At the end of the report, provide some key match statistics (overall score, shots, penalties)
-and 3 starts of the game (with their respective stats).
+and 3 stars of the game (with their respective stats).
 
 Play-by-Play:
 {play_by_play}


### PR DESCRIPTION
## Summary
- correct "starts" typo to "stars" in game summary prompt
- ensure prompt file ends with a trailing newline for consistency

## Testing
- `pytest` *(fails: ImportError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68a98c574564832bbf66a6b7b404b238