### PR TITLE
Add google-cloud-storage dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 requests
 python-dotenv
 nhlpy
+google-cloud-storage


### PR DESCRIPTION
## Summary
- add google-cloud-storage to requirements

## Testing
- `pip install -r requirements.txt` (fails: Could not connect to proxy)
- `pytest` (fails: ModuleNotFoundError: No module named 'google')

------
https://chatgpt.com/codex/tasks/task_e_68a98c51a0ec832bacf16e7f0b928639