### PR TITLE
Enable direct engine imports in tests

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,11 +1,19 @@
 """Core engine modules for processing NHL events."""
 
-from .transform import transform_event
-from .generate_summary import generate_summary
-from .ai_summary import generate_ai_summary
-from .process_game import process_game_events
-from .summarize_game import summarize_game
-from .date_index import mark_artifact, list_games_missing
+from . import (
+    transform,
+    generate_summary,
+    ai_summary,
+    process_game,
+    summarize_game,
+    date_index,
+)
 
-__all__ = ["transform_event", "generate_summary", "generate_ai_summary", "process_game_events",
-           "summarize_game", "mark_artifact", "list_games_missing"]
+__all__ = [
+    "transform",
+    "generate_summary",
+    "ai_summary",
+    "process_game",
+    "summarize_game",
+    "date_index",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "nhl-commentary-core"
+version = "0.1.0"
+description = "Core components for NHL commentary"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -3,12 +3,37 @@ from types import SimpleNamespace
 
 import pytest
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 # Ensure module can import without hitting the network
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
-import engine.ai_summary as ai_summary
+fake_nhlpy = SimpleNamespace(NHLClient=lambda: SimpleNamespace())
+sys.modules['nhlpy'] = fake_nhlpy
+
+class _FakeStorageClient:
+    @classmethod
+    def from_service_account_json(cls, *args, **kwargs):
+        return cls()
+
+    def bucket(self, *args, **kwargs):
+        return SimpleNamespace(
+            blob=lambda *a, **kw: SimpleNamespace(
+                exists=lambda: False,
+                download_as_text=lambda: "",
+                upload_from_string=lambda *a, **kw: None,
+            )
+        )
+
+fake_storage = SimpleNamespace(Client=_FakeStorageClient, Bucket=SimpleNamespace)
+fake_exceptions = SimpleNamespace(NotFound=Exception)
+fake_google_cloud = SimpleNamespace(storage=fake_storage)
+fake_google_api_core = SimpleNamespace(exceptions=fake_exceptions)
+sys.modules.setdefault("google", SimpleNamespace(cloud=fake_google_cloud, api_core=fake_google_api_core))
+sys.modules.setdefault("google.cloud", fake_google_cloud)
+sys.modules.setdefault("google.cloud.storage", fake_storage)
+sys.modules.setdefault("google.api_core", fake_google_api_core)
+sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
+
+import engine.ai_summary
 
 
 def test_generate_ai_summary_includes_payloads(monkeypatch):
@@ -22,10 +47,10 @@ def test_generate_ai_summary_includes_payloads(monkeypatch):
         assert "Player One" in input_payload
         return SimpleNamespace(output_text=expected)
 
-    monkeypatch.setattr(ai_summary.client.responses, "create", fake_create)
+    monkeypatch.setattr(engine.ai_summary.client.responses, "create", fake_create)
 
 
-    summary = ai_summary.generate_ai_summary(play_by_play, game_story)
+    summary = engine.ai_summary.generate_ai_summary(play_by_play, game_story)
     assert summary == expected
 
 
@@ -36,17 +61,17 @@ def test_generate_ai_summary_handles_error(monkeypatch):
     def fake_create(*args, **kwargs):
         raise Exception("boom")
 
-    monkeypatch.setattr(ai_summary.client.responses, "create", fake_create)
+    monkeypatch.setattr(engine.ai_summary.client.responses, "create", fake_create)
 
     with pytest.raises(RuntimeError, match="boom"):
-        ai_summary.generate_ai_summary(play_by_play, game_story)
+        engine.ai_summary.generate_ai_summary(play_by_play, game_story)
 
 
 def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
-        importlib.reload(ai_summary)
+        importlib.reload(engine.ai_summary)
 
     # Restore for subsequent tests
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    importlib.reload(ai_summary)
+    importlib.reload(engine.ai_summary)

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,4 +1,35 @@
-from engine.generate_summary import generate_summary
+import sys, os, types
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
+sys.modules['nhlpy'] = fake_nhlpy
+
+class _FakeStorageClient:
+    @classmethod
+    def from_service_account_json(cls, *args, **kwargs):
+        return cls()
+
+    def bucket(self, *args, **kwargs):
+        return types.SimpleNamespace(
+            blob=lambda *a, **kw: types.SimpleNamespace(
+                exists=lambda: False,
+                download_as_text=lambda: "",
+                upload_from_string=lambda *a, **kw: None,
+            )
+        )
+
+fake_storage = types.SimpleNamespace(Client=_FakeStorageClient, Bucket=types.SimpleNamespace)
+fake_exceptions = types.SimpleNamespace(NotFound=Exception)
+fake_google_cloud = types.SimpleNamespace(storage=fake_storage)
+fake_google_api_core = types.SimpleNamespace(exceptions=fake_exceptions)
+sys.modules.setdefault("google", types.SimpleNamespace(cloud=fake_google_cloud, api_core=fake_google_api_core))
+sys.modules.setdefault("google.cloud", fake_google_cloud)
+sys.modules.setdefault("google.cloud.storage", fake_storage)
+sys.modules.setdefault("google.api_core", fake_google_api_core)
+sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
+
+import engine.generate_summary
 
 
 def test_generate_summary_team_breakdown():
@@ -9,7 +40,7 @@ def test_generate_summary_team_breakdown():
         {"event_type": "hit", "period": 2, "team_id": 2},
     ]
 
-    summary = generate_summary(events)
+    summary = engine.generate_summary.generate_summary(events)
 
     assert "Team Comparison" in summary
     assert "- Team 1: G 1, SOG 1, PIM 1" in summary
@@ -91,7 +122,7 @@ def test_generate_summary_player_info():
         },
     ]
 
-    summary = generate_summary(events)
+    summary = engine.generate_summary.generate_summary(events)
 
     assert "3 Stars of the Game" in summary
     assert "- Star 1: Player One (Flyers) (C) - Goals: 2, Assists: 0, Points: 2" in summary

--- a/tests/test_process_game.py
+++ b/tests/test_process_game.py
@@ -1,13 +1,35 @@
 import sys, os, types
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
-
 
 fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
 sys.modules['nhlpy'] = fake_nhlpy
 
-from engine.process_game import process_game_events
+class _FakeStorageClient:
+    @classmethod
+    def from_service_account_json(cls, *args, **kwargs):
+        return cls()
+
+    def bucket(self, *args, **kwargs):
+        return types.SimpleNamespace(
+            blob=lambda *a, **kw: types.SimpleNamespace(
+                exists=lambda: False,
+                download_as_text=lambda: "",
+                upload_from_string=lambda *a, **kw: None,
+            )
+        )
+
+fake_storage = types.SimpleNamespace(Client=_FakeStorageClient, Bucket=types.SimpleNamespace)
+fake_exceptions = types.SimpleNamespace(NotFound=Exception)
+fake_google_cloud = types.SimpleNamespace(storage=fake_storage)
+fake_google_api_core = types.SimpleNamespace(exceptions=fake_exceptions)
+sys.modules.setdefault("google", types.SimpleNamespace(cloud=fake_google_cloud, api_core=fake_google_api_core))
+sys.modules.setdefault("google.cloud", fake_google_cloud)
+sys.modules.setdefault("google.cloud.storage", fake_storage)
+sys.modules.setdefault("google.api_core", fake_google_api_core)
+sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
+
+import engine.process_game
 
 
 def test_process_game_events_adds_three_stars(monkeypatch):
@@ -46,7 +68,7 @@ def test_process_game_events_adds_three_stars(monkeypatch):
     monkeypatch.setattr("engine.process_game.get_play_by_play", fake_get_play_by_play)
     monkeypatch.setattr("engine.process_game.get_game_story", fake_get_game_story)
 
-    events = process_game_events(123)
+    events = engine.process_game.process_game_events(123)
     assert {
         "event_type": "star",
         "star": 1,
@@ -93,7 +115,7 @@ def test_process_game_events_adds_goal_names(monkeypatch):
     monkeypatch.setattr("engine.process_game.get_play_by_play", fake_get_play_by_play)
     monkeypatch.setattr("engine.process_game.get_game_story", fake_get_game_story)
 
-    events = process_game_events(456)
+    events = engine.process_game.process_game_events(456)
     goal_event = events[0]
     players = goal_event["players"]
     assert players["scorer_name"] == "John Doe"

--- a/tests/test_summarize_game.py
+++ b/tests/test_summarize_game.py
@@ -1,12 +1,35 @@
 import sys, os, types
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
 sys.modules['nhlpy'] = fake_nhlpy
 
-from engine.summarize_game import summarize_game
+class _FakeStorageClient:
+    @classmethod
+    def from_service_account_json(cls, *args, **kwargs):
+        return cls()
+
+    def bucket(self, *args, **kwargs):
+        return types.SimpleNamespace(
+            blob=lambda *a, **kw: types.SimpleNamespace(
+                exists=lambda: False,
+                download_as_text=lambda: "",
+                upload_from_string=lambda *a, **kw: None,
+            )
+        )
+
+fake_storage = types.SimpleNamespace(Client=_FakeStorageClient, Bucket=types.SimpleNamespace)
+fake_exceptions = types.SimpleNamespace(NotFound=Exception)
+fake_google_cloud = types.SimpleNamespace(storage=fake_storage)
+fake_google_api_core = types.SimpleNamespace(exceptions=fake_exceptions)
+sys.modules.setdefault("google", types.SimpleNamespace(cloud=fake_google_cloud, api_core=fake_google_api_core))
+sys.modules.setdefault("google.cloud", fake_google_cloud)
+sys.modules.setdefault("google.cloud.storage", fake_storage)
+sys.modules.setdefault("google.api_core", fake_google_api_core)
+sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
+
+import engine.summarize_game
 
 
 def test_summarize_game_rule_based(monkeypatch):
@@ -14,7 +37,7 @@ def test_summarize_game_rule_based(monkeypatch):
         assert game_id == 1
         return ["event"]
 
-    def fake_generate_summary(events):
+    def fake_get_or_build_stats_summary(game_id, events, date=None):
         assert events == ["event"]
         return "rule summary"
 
@@ -22,10 +45,10 @@ def test_summarize_game_rule_based(monkeypatch):
         raise AssertionError("AI summary should not be called")
 
     monkeypatch.setattr("engine.summarize_game.process_game_events", fake_process_game_events)
-    monkeypatch.setattr("engine.summarize_game.generate_summary", fake_generate_summary)
+    monkeypatch.setattr("engine.summarize_game.get_or_build_stats_summary", fake_get_or_build_stats_summary)
     monkeypatch.setattr("engine.summarize_game.generate_ai_summary", fake_generate_ai_summary)
 
-    summary = summarize_game(1, use_ai=False)
+    summary = engine.summarize_game.summarize_game(1, use_ai=False)
     assert summary == "rule summary"
 
 
@@ -34,7 +57,7 @@ def test_summarize_game_ai(monkeypatch):
         assert game_id == 2
         return ["event"]
 
-    def fake_generate_summary(events):
+    def fake_get_or_build_stats_summary(game_id, events, date=None):
         raise AssertionError("Rule-based summary should not be called")
 
     def fake_generate_ai_summary(play_by_play, game_story):
@@ -43,10 +66,10 @@ def test_summarize_game_ai(monkeypatch):
         return "ai summary"
 
     monkeypatch.setattr("engine.summarize_game.process_game_events", fake_process_game_events)
-    monkeypatch.setattr("engine.summarize_game.generate_summary", fake_generate_summary)
+    monkeypatch.setattr("engine.summarize_game.get_or_build_stats_summary", fake_get_or_build_stats_summary)
     monkeypatch.setattr("engine.summarize_game.generate_ai_summary", fake_generate_ai_summary)
     monkeypatch.setattr("engine.summarize_game.get_play_by_play", lambda game_id: ["event"])
     monkeypatch.setattr("engine.summarize_game.get_game_story", lambda game_id: {"story": "data"})
 
-    summary = summarize_game(2, use_ai=True)
+    summary = engine.summarize_game.summarize_game(2, use_ai=True)
     assert summary == "ai summary"

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,6 +1,37 @@
+import sys, os, types
+
 import pytest
 
-from engine.transform import transform_event
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
+sys.modules['nhlpy'] = fake_nhlpy
+
+class _FakeStorageClient:
+    @classmethod
+    def from_service_account_json(cls, *args, **kwargs):
+        return cls()
+
+    def bucket(self, *args, **kwargs):
+        return types.SimpleNamespace(
+            blob=lambda *a, **kw: types.SimpleNamespace(
+                exists=lambda: False,
+                download_as_text=lambda: "",
+                upload_from_string=lambda *a, **kw: None,
+            )
+        )
+
+fake_storage = types.SimpleNamespace(Client=_FakeStorageClient, Bucket=types.SimpleNamespace)
+fake_exceptions = types.SimpleNamespace(NotFound=Exception)
+fake_google_cloud = types.SimpleNamespace(storage=fake_storage)
+fake_google_api_core = types.SimpleNamespace(exceptions=fake_exceptions)
+sys.modules.setdefault("google", types.SimpleNamespace(cloud=fake_google_cloud, api_core=fake_google_api_core))
+sys.modules.setdefault("google.cloud", fake_google_cloud)
+sys.modules.setdefault("google.cloud.storage", fake_storage)
+sys.modules.setdefault("google.api_core", fake_google_api_core)
+sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
+
+import engine.transform
 
 
 def test_transform_handles_missing_type_desc_key():
@@ -9,6 +40,6 @@ def test_transform_handles_missing_type_desc_key():
         # No 'typeDescKey' field
         "details": {},
     }
-    result = transform_event(event)
+    result = engine.transform.transform_event(event)
     assert result["event_type"] == "unknown"
     assert result["raw_data"] == event


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with pytest configuration for package discovery
- expose engine submodules directly and update tests to import them
- remove `sys.path` hacks in tests and patch external dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a98c4442c8832b8e32278ff886496d