### PR TITLE
Centralize configuration loading and expand ingestion coverage

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,62 @@
+"""Centralized runtime configuration for nhl-commentary-core."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator
+
+from dotenv import load_dotenv
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime configuration values."""
+
+    gcs_bucket_name: str
+
+
+_override_stack: list[Settings] = []
+_default_settings: Settings | None = None
+
+
+def _build_settings() -> Settings:
+    """Load settings from environment variables (with dotenv support)."""
+    load_dotenv()
+    bucket = os.getenv("GCS_BUCKET_NAME", "nhl-commentary-bucket")
+    if not bucket:
+        raise RuntimeError("Missing GCS_BUCKET_NAME environment variable")
+    return Settings(gcs_bucket_name=bucket)
+
+
+def get_settings() -> Settings:
+    """Return the active settings, honoring any overrides."""
+    if _override_stack:
+        return _override_stack[-1]
+    global _default_settings
+    if _default_settings is None:
+        _default_settings = _build_settings()
+    return _default_settings
+
+
+@contextmanager
+def override_settings(settings: Settings) -> Iterator[Settings]:
+    """Temporarily override runtime settings (useful for tests)."""
+    _override_stack.append(settings)
+    try:
+        yield settings
+    finally:
+        if _override_stack:
+            _override_stack.pop()
+
+
+def clear_overrides() -> None:
+    """Remove all active overrides (useful between tests)."""
+    _override_stack.clear()
+
+
+def reload_settings() -> Settings:
+    """Force settings to reload from environment variables."""
+    global _default_settings
+    _default_settings = _build_settings()
+    return _default_settings

--- a/data_fetch/game_story.py
+++ b/data_fetch/game_story.py
@@ -1,15 +1,21 @@
-from nhlpy import NHLClient
+import logging
 from typing import Any, Dict, Optional, Tuple
-from gcp_ingestion import check_file_exists, download_json, upload_json
-from engine.date_index import mark_artifact
-from dotenv import load_dotenv
-from os import getenv
 
-# Load environment variables
-load_dotenv()
-bucket_name = getenv("GCS_BUCKET_NAME", "nhl-commentary-bucket")
-if not bucket_name:
-    raise RuntimeError("Missing GCS_BUCKET_NAME environment variable")
+from nhlpy import NHLClient
+
+from config import get_settings
+from gcp_ingestion import check_file_exists, download_json, upload_json
+
+try:  # engine module may not be available in all runtimes
+    from engine.date_index import mark_artifact
+except Exception:  # pragma: no cover - optional dependency
+    mark_artifact = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+def _bucket_name() -> str:
+    return get_settings().gcs_bucket_name
 
 GS_BLOB = "raw/game_story/{game_id}.json"
 
@@ -66,13 +72,21 @@ def _maybe_mark_index(story: Dict[str, Any],
     a, h = _infer_abbrs(story)
     away = away_abbr or a
     home = home_abbr or h
-    if d:
+    if d and mark_artifact:
         try:
-            mark_artifact(bucket_name, date=d, game_id=game_id,
-                          away=away, home=home,
-                          artifact="raw_story", exists=True)
+            mark_artifact(
+                _bucket_name(),
+                date=d,
+                game_id=game_id,
+                away=away,
+                home=home,
+                artifact="raw_story",
+                exists=True,
+            )
         except Exception:
-            pass  # index is convenience only
+            logger.warning(
+                "Failed to mark raw_story index for game %s on %s", game_id, d, exc_info=True
+            )
 
 
 def get_game_story(
@@ -101,11 +115,12 @@ def get_game_story(
         GameStoryFetchError: On retrieval/validation errors.
     """
     blob_path = GS_BLOB.format(game_id=game_id)
+    bucket = _bucket_name()
 
     # 1) Cache
-    if not force_refresh and check_file_exists(bucket_name, blob_path):
+    if not force_refresh and check_file_exists(bucket, blob_path):
         try:
-            cached = download_json(bucket_name, blob_path)
+            cached = download_json(bucket, blob_path)
             if _looks_like_gs(cached):
                 _maybe_mark_index(cached, game_id=game_id,
                                   date=date, away_abbr=away_abbr, home_abbr=home_abbr,
@@ -130,9 +145,11 @@ def get_game_story(
 
         # 3) Best-effort cache write
         try:
-            upload_json(bucket_name, blob_path, story)
+            upload_json(bucket, blob_path, story)
         except Exception:
-            pass
+            logger.warning(
+                "Failed to upload game story cache for game %s", game_id, exc_info=True
+            )
 
         _maybe_mark_index(story, game_id=game_id,
                           date=date, away_abbr=away_abbr, home_abbr=home_abbr,

--- a/data_fetch/play_by_play.py
+++ b/data_fetch/play_by_play.py
@@ -1,15 +1,21 @@
-from nhlpy import NHLClient
+import logging
 from typing import Any, Dict, Optional, Tuple
-from gcp_ingestion import check_file_exists, download_json, upload_json
-from engine.date_index import mark_artifact  # <-- add this import
-from dotenv import load_dotenv
-from os import getenv
 
-# Load environment variables
-load_dotenv()
-bucket_name = getenv("GCS_BUCKET_NAME", "nhl-commentary-bucket")
-if not bucket_name:
-    raise RuntimeError("Missing GCS_BUCKET_NAME environment variable")
+from nhlpy import NHLClient
+
+from config import get_settings
+from gcp_ingestion import check_file_exists, download_json, upload_json
+
+try:  # engine is optional in some environments (e.g. tests)
+    from engine.date_index import mark_artifact
+except Exception:  # pragma: no cover - optional dependency
+    mark_artifact = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+def _bucket_name() -> str:
+    return get_settings().gcs_bucket_name
 
 PBP_BLOB = "raw/play_by_play/{game_id}.json"
 
@@ -51,14 +57,21 @@ def _maybe_mark_index(pbp: Dict[str, Any],
     a, h = _infer_abbrs(pbp)
     away = away_abbr or a
     home = home_abbr or h
-    if d:
+    if d and mark_artifact:
         try:
-            mark_artifact(bucket_name, date=d, game_id=game_id,
-                          away=away, home=home,
-                          artifact="raw_pbp", exists=True)
+            mark_artifact(
+                _bucket_name(),
+                date=d,
+                game_id=game_id,
+                away=away,
+                home=home,
+                artifact="raw_pbp",
+                exists=True,
+            )
         except Exception:
-            # Non-fatal; index is a convenience
-            pass
+            logger.warning(
+                "Failed to mark raw_pbp index for game %s on %s", game_id, d, exc_info=True
+            )
 
 def get_play_by_play(
     game_id: int,
@@ -74,10 +87,11 @@ def get_play_by_play(
     Optionally updates a per-date index with a 'raw_pbp' flag.
     """
     blob_path = PBP_BLOB.format(game_id=game_id)
+    bucket = _bucket_name()
 
     # 1) Cache
-    if not force_refresh and check_file_exists(bucket_name, blob_path):
-        pbp = download_json(bucket_name, blob_path)
+    if not force_refresh and check_file_exists(bucket, blob_path):
+        pbp = download_json(bucket, blob_path)
         if _looks_like_pbp(pbp):
             _maybe_mark_index(pbp, game_id=game_id,
                               date=date, away_abbr=away_abbr, home_abbr=home_abbr,
@@ -100,9 +114,11 @@ def get_play_by_play(
 
         # 3) Best-effort cache write
         try:
-            upload_json(bucket_name, blob_path, pbp)
+            upload_json(bucket, blob_path, pbp)
         except Exception:
-            pass
+            logger.warning(
+                "Failed to upload play-by-play cache for game %s", game_id, exc_info=True
+            )
 
         _maybe_mark_index(pbp, game_id=game_id,
                           date=date, away_abbr=away_abbr, home_abbr=home_abbr,

--- a/data_fetch/schedule.py
+++ b/data_fetch/schedule.py
@@ -1,12 +1,18 @@
-from nhlpy import NHLClient
+import logging
 from typing import List, Optional
+
+from nhlpy import NHLClient
+
+from config import get_settings
 from models.game_schedule import GameSchedule
 
 # Optional: only if you want to prefill the date index
 try:
     from engine.date_index import mark_artifact  # your simple index helper
-except Exception:
-    mark_artifact = None  # keeps this import optional
+except Exception:  # pragma: no cover - optional dependency
+    mark_artifact = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 class ScheduleFetchError(Exception):
     """Raised when fetching the schedule fails."""
@@ -60,11 +66,16 @@ def get_schedule(
     ]
 
     # Seed the simple per-date index with matchups (no artifacts yet)
-    if mark_index and bucket_name and mark_artifact is not None:
+    if mark_index:
+        bucket = bucket_name or get_settings().gcs_bucket_name
+    else:
+        bucket = None
+
+    if mark_index and bucket and mark_artifact is not None:
         for s in schedules:
             try:
                 mark_artifact(
-                    bucket_name,
+                    bucket,
                     date=date,
                     game_id=s.game_id,
                     away=s.away_team,
@@ -75,7 +86,7 @@ def get_schedule(
                 # Also ensure 'raw_story' key exists (False) so your
                 # list_games_missing(...) works immediately.
                 mark_artifact(
-                    bucket_name,
+                    bucket,
                     date=date,
                     game_id=s.game_id,
                     artifact="raw_story",
@@ -83,6 +94,8 @@ def get_schedule(
                 )
             except Exception:
                 # Non-fatal; schedule fetch should not fail due to index writes
-                pass
+                logger.warning(
+                    "Failed to seed index for game %s on %s", s.game_id, date, exc_info=True
+                )
 
     return schedules

--- a/engine/summaries.py
+++ b/engine/summaries.py
@@ -1,8 +1,8 @@
 # engine/summaries.py
-from typing import List, Dict, Optional
-from os import getenv
-from dotenv import load_dotenv
+import logging
+from typing import Dict, List, Optional
 
+from config import get_settings
 from gcp_ingestion import check_file_exists, download_text, upload_text
 
 # Lazy import inside functions to avoid any possible import loops:
@@ -15,8 +15,11 @@ def _mark(artifact: str, *, bucket: str, date: Optional[str], game_id: int) -> N
     except Exception:
         pass  # index is convenience only
 
-load_dotenv()
-_BUCKET = getenv("GCS_BUCKET_NAME", "nhl-commentary-bucket")
+logger = logging.getLogger(__name__)
+
+
+def _bucket() -> str:
+    return get_settings().gcs_bucket_name
 
 _STATS_BLOB = "derived/summary/stats/{game_id}.txt"
 _AI_BLOB    = "derived/summary/ai/{game_id}.md"
@@ -37,15 +40,16 @@ def get_or_build_stats_summary(
         from engine.generate_summary import generate_summary as _gen
         generator_fn = _gen
 
-    blob = _STATSBLOB = _STATS_BLOB.format(game_id=game_id)
+    bucket = _bucket()
+    blob = _STATS_BLOB.format(game_id=game_id)
 
-    if not force_refresh and check_file_exists(_BUCKET, blob):
-        return download_text(_BUCKET, blob)
+    if not force_refresh and check_file_exists(bucket, blob):
+        return download_text(bucket, blob)
 
     # Build, upload, mark index
     summary = generator_fn(events)
-    upload_text(_BUCKET, blob, summary, content_type="text/plain")
-    _mark("summary_stats", bucket=_BUCKET, date=date, game_id=game_id)
+    upload_text(bucket, blob, summary, content_type="text/plain")
+    _mark("summary_stats", bucket=bucket, date=date, game_id=game_id)
     return summary
 
 
@@ -53,17 +57,19 @@ def save_ai_summary(*, game_id: int, md: str, date: Optional[str] = None) -> Non
     """
     Persist an AI-written markdown summary and mark the date index.
     """
+    bucket = _bucket()
     blob = _AI_BLOB.format(game_id=game_id)
-    upload_text(_BUCKET, blob, md, content_type="text/markdown")
-    _mark("summary_ai", bucket=_BUCKET, date=date, game_id=game_id)
-    print(f"AI summary for game {game_id} saved to {_BUCKET}/{blob}")
+    upload_text(bucket, blob, md, content_type="text/markdown")
+    _mark("summary_ai", bucket=bucket, date=date, game_id=game_id)
+    logger.info("AI summary for game %s saved to %s/%s", game_id, bucket, blob)
 
 
 def load_ai_summary(*, game_id: int) -> Optional[str]:
     """
     Load an AI summary if it exists; return None otherwise.
     """
+    bucket = _bucket()
     blob = _AI_BLOB.format(game_id=game_id)
-    if not check_file_exists(_BUCKET, blob):
+    if not check_file_exists(bucket, blob):
         return None
-    return download_text(_BUCKET, blob)
+    return download_text(bucket, blob)

--- a/gcp_ingestion/__init__.py
+++ b/gcp_ingestion/__init__.py
@@ -1,9 +1,21 @@
-from .storage import upload_json, check_file_exists, download_json, upload_text, download_text
+from .storage import (
+    check_file_exists,
+    download_json,
+    download_text,
+    get_storage_client,
+    override_storage_client,
+    reset_storage_client,
+    upload_json,
+    upload_text,
+)
 
 __all__ = [
-    "upload_json",
     "check_file_exists",
     "download_json",
+    "download_text",
+    "get_storage_client",
+    "override_storage_client",
+    "reset_storage_client",
+    "upload_json",
     "upload_text",
-    "download_text"
 ]

--- a/gcp_ingestion/storage.py
+++ b/gcp_ingestion/storage.py
@@ -1,8 +1,15 @@
 import json
+import logging
 import os
-from typing import Any, Dict
-from google.cloud import storage
+from contextlib import contextmanager
+from functools import lru_cache
+from typing import Any, Dict, Iterator, Optional
+
 from google.api_core.exceptions import NotFound
+from google.cloud import storage
+
+logger = logging.getLogger(__name__)
+
 
 def _make_client() -> storage.Client:
     """
@@ -15,42 +22,89 @@ def _make_client() -> storage.Client:
         return storage.Client.from_service_account_json(cred_path)
     return storage.Client()  # ADC
 
-_client: storage.Client = _make_client()
 
-def _get_bucket(bucket_name: str) -> storage.Bucket:
-    return _client.bucket(bucket_name)
+@lru_cache(maxsize=1)
+def _cached_client() -> storage.Client:
+    return _make_client()
 
-def check_file_exists(bucket_name: str, blob_name: str) -> bool:
-    bucket = _get_bucket(bucket_name)
+
+_override_stack: list[storage.Client] = []
+
+
+def get_storage_client() -> storage.Client:
+    if _override_stack:
+        return _override_stack[-1]
+    return _cached_client()
+
+
+def reset_storage_client() -> None:
+    """Clear the cached client (useful when env vars change)."""
+    _cached_client.cache_clear()
+
+
+@contextmanager
+def override_storage_client(client: storage.Client) -> Iterator[storage.Client]:
+    _override_stack.append(client)
+    try:
+        yield client
+    finally:
+        if _override_stack:
+            _override_stack.pop()
+
+
+def _get_bucket(bucket_name: str, *, client: Optional[storage.Client] = None) -> storage.Bucket:
+    return (client or get_storage_client()).bucket(bucket_name)
+
+def check_file_exists(
+    bucket_name: str, blob_name: str, *, client: Optional[storage.Client] = None
+) -> bool:
+    bucket = _get_bucket(bucket_name, client=client)
     blob = bucket.blob(blob_name)
     try:
         return blob.exists()
     except NotFound:
         return False
 
-def download_json(bucket_name: str, blob_name: str) -> Dict[str, Any]:
-    bucket = _get_bucket(bucket_name)
+def download_json(
+    bucket_name: str, blob_name: str, *, client: Optional[storage.Client] = None
+) -> Dict[str, Any]:
+    bucket = _get_bucket(bucket_name, client=client)
     blob = bucket.blob(blob_name)
     text = blob.download_as_text()  # raises if missing; let caller handle
     return json.loads(text)
 
-def upload_json(bucket_name: str, blob_name: str, payload: Any) -> None:
-    bucket = _get_bucket(bucket_name)
+def upload_json(
+    bucket_name: str,
+    blob_name: str,
+    payload: Any,
+    *,
+    client: Optional[storage.Client] = None,
+) -> None:
+    bucket = _get_bucket(bucket_name, client=client)
     # Best practice: don't auto-create buckets here. Assume infra created outside.
     blob = bucket.blob(blob_name)
     blob.upload_from_string(
         data=json.dumps(payload, ensure_ascii=False, indent=2),
         content_type="application/json",
     )
-    print(f"✅ Uploaded JSON → gs://{bucket_name}/{blob_name}")
+    logger.info("Uploaded JSON to gs://%s/%s", bucket_name, blob_name)
 
-def download_text(bucket_name: str, blob_name: str) -> str:
-    bucket = _get_bucket(bucket_name)
+def download_text(
+    bucket_name: str, blob_name: str, *, client: Optional[storage.Client] = None
+) -> str:
+    bucket = _get_bucket(bucket_name, client=client)
     blob = bucket.blob(blob_name)
     return blob.download_as_text()
 
-def upload_text(bucket_name: str, blob_name: str, text: str, content_type: str = "text/plain") -> None:
-    bucket = _get_bucket(bucket_name)
+def upload_text(
+    bucket_name: str,
+    blob_name: str,
+    text: str,
+    content_type: str = "text/plain",
+    *,
+    client: Optional[storage.Client] = None,
+) -> None:
+    bucket = _get_bucket(bucket_name, client=client)
     blob = bucket.blob(blob_name)
     blob.upload_from_string(data=text, content_type=content_type)
-    print(f"✅ Uploaded text → gs://{bucket_name}/{blob_name}")
+    logger.info("Uploaded text to gs://%s/%s", bucket_name, blob_name)

--- a/main.py
+++ b/main.py
@@ -1,12 +1,61 @@
 import argparse
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
 
 from data_fetch.schedule import get_schedule
 from engine.summarize_game import summarize_game
+from models.game_schedule import GameSchedule
 
-DATE = "2025-04-01"  # Fallback date if user input is empty
+DEFAULT_DATE = "2025-04-01"  # Fallback date if user input is empty
 
-def main():
+logger = logging.getLogger(__name__)
+
+
+class GameSelectionError(RuntimeError):
+    """Raised when a requested game cannot be determined."""
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    summary: Optional[str]
+    game: GameSchedule
+
+
+def _select_game(schedule: Iterable[GameSchedule], *, game_id: Optional[int]) -> GameSchedule:
+    games = list(schedule)
+    if not games:
+        raise GameSelectionError("No games available for the requested date.")
+    if game_id is None:
+        if len(games) == 1:
+            return games[0]
+        raise GameSelectionError(
+            "Multiple games scheduled; specify `game_id` for deterministic selection."
+        )
+    for game in games:
+        if game.game_id == game_id:
+            return game
+    raise GameSelectionError(f"Game {game_id} not found in schedule.")
+
+
+def generate_summary_for_date(
+    date: str,
+    *,
+    game_id: Optional[int] = None,
+    use_ai: bool = True,
+) -> SummaryResult:
+    """Programmatic entry point for summarizing a game on a given date."""
+
+    schedule = get_schedule(date)
+    game = _select_game(schedule, game_id=game_id)
+    summary = summarize_game(game.game_id, use_ai=use_ai)
+    return SummaryResult(summary=summary, game=game)
+
+
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Summarize an NHL game")
+    parser.add_argument("--date", help="Game date (YYYY-MM-DD)")
+    parser.add_argument("--game-id", type=int, help="NHL game ID to summarize")
     parser.add_argument("--ai", dest="use_ai", action="store_true", help="Use AI summary")
     parser.add_argument(
         "--rule",
@@ -14,10 +63,17 @@ def main():
         action="store_false",
         help="Use rule-based summary",
     )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail instead of prompting for missing values.",
+    )
     parser.set_defaults(use_ai=None)
-    args = parser.parse_args()
+    return parser
 
-    date = input("Enter game date (YYYY-MM-DD): ").strip() or DATE
+
+def _interactive_flow(args: argparse.Namespace) -> None:
+    date = args.date or input("Enter game date (YYYY-MM-DD): ").strip() or DEFAULT_DATE
     schedule = get_schedule(date)
 
     if not schedule:
@@ -28,27 +84,74 @@ def main():
     for idx, game in enumerate(schedule, start=1):
         print(f"{idx}. {game.away_team} at {game.home_team} (ID: {game.game_id})")
 
-    selection = input("Select a game number: ").strip()
-    try:
-        game = schedule[int(selection) - 1]
-    except (ValueError, IndexError):
-        print("Invalid selection.")
-        return
+    selection = args.game_id
+    if selection is None:
+        selection_input = input("Select a game number: ").strip()
+        try:
+            selection = schedule[int(selection_input) - 1].game_id
+        except (ValueError, IndexError):
+            print("Invalid selection.")
+            return
 
-    print(f"Processing Game ID: {game.game_id} ({game.home_team} vs {game.away_team})")
     use_ai = args.use_ai
     if use_ai is None:
         choice = input("Use AI-generated summary? [Y/n]: ").strip().lower()
         use_ai = choice != "n"
 
     try:
-        summary = summarize_game(game.game_id, use_ai=use_ai)
-        if summary:
-            print(summary)
+        result = generate_summary_for_date(date, game_id=selection, use_ai=use_ai)
+    except GameSelectionError as exc:
+        print(str(exc))
+        return
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Failed to summarize game interactively")
+        print(f"❌ Failed to process game {selection}: {exc}")
+        return
+
+    game = result.game
+    print(f"Processing Game ID: {game.game_id} ({game.home_team} vs {game.away_team})")
+    if result.summary:
+        print(result.summary)
+    else:
+        print(f"⚠️ No events for game {game.game_id}")
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.non_interactive:
+        missing = [
+            flag
+            for flag, value in (
+                ("--date", args.date),
+                ("--game-id", args.game_id),
+                ("--ai/--rule", args.use_ai),
+            )
+            if value is None
+        ]
+        if missing:
+            parser.error(
+                "Non-interactive mode requires explicit values for: " + ", ".join(missing)
+            )
+        try:
+            result = generate_summary_for_date(
+                args.date,
+                game_id=args.game_id,
+                use_ai=args.use_ai,
+            )
+        except Exception as exc:
+            logger.exception("Failed to summarize game")
+            raise SystemExit(str(exc)) from exc
+
+        if result.summary:
+            print(result.summary)
         else:
-            print(f"⚠️ No events for game {game.game_id}")
-    except Exception as e:
-        print(f"❌ Failed to process game {game.game_id}: {e}")
+            print(f"⚠️ No events for game {result.game.game_id}")
+        return
+
+    _interactive_flow(args)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,16 @@
+import config
+
+
+def test_override_settings_context_manager():
+    original = config.get_settings()
+    override = config.Settings(gcs_bucket_name="test-bucket")
+    with config.override_settings(override):
+        assert config.get_settings() is override
+    assert config.get_settings().gcs_bucket_name == original.gcs_bucket_name
+
+
+def test_clear_overrides_resets_stack():
+    override = config.Settings(gcs_bucket_name="another")
+    with config.override_settings(override):
+        config.clear_overrides()
+        assert config.get_settings() is not override

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -1,0 +1,36 @@
+import pytest
+
+import main
+from models.game_schedule import GameSchedule
+
+
+def make_game(game_id: int) -> GameSchedule:
+    return GameSchedule(
+        game_id=game_id,
+        season_id="20242025",
+        game_type="R",
+        home_team="MTL",
+        home_team_score=3,
+        away_team="COL",
+        away_team_score=2,
+        winning_goal_scorer_id=42,
+    )
+
+
+def test_generate_summary_for_date_requires_game_id_for_multiple_games(monkeypatch):
+    monkeypatch.setattr(main, "get_schedule", lambda date: [make_game(1), make_game(2)])
+    with pytest.raises(main.GameSelectionError):
+        main.generate_summary_for_date("2025-04-25")
+
+
+def test_generate_summary_for_date_returns_summary(monkeypatch):
+    monkeypatch.setattr(main, "get_schedule", lambda date: [make_game(99)])
+    monkeypatch.setattr(main, "summarize_game", lambda game_id, use_ai: f"summary-{game_id}-{use_ai}")
+    result = main.generate_summary_for_date("2025-04-25", use_ai=False)
+    assert result.summary == "summary-99-False"
+    assert result.game.game_id == 99
+
+
+def test_non_interactive_requires_arguments(monkeypatch):
+    with pytest.raises(SystemExit):
+        main.main(["--non-interactive"])

--- a/tests/test_play_by_play_cache.py
+++ b/tests/test_play_by_play_cache.py
@@ -1,0 +1,63 @@
+import config
+from data_fetch import play_by_play
+
+
+def test_get_play_by_play_uses_cache(monkeypatch):
+    called = {"client": False}
+
+    def fake_client():  # pragma: no cover - should not be hit
+        called["client"] = True
+        raise AssertionError("Client should not be instantiated when cache is hit")
+
+    monkeypatch.setattr(play_by_play, "NHLClient", fake_client)
+    monkeypatch.setattr(play_by_play, "check_file_exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr(play_by_play, "download_json", lambda *args, **kwargs: {"plays": []})
+    monkeypatch.setattr(
+        play_by_play,
+        "upload_json",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Should not upload on cache hit")),
+    )
+
+    with config.override_settings(config.Settings(gcs_bucket_name="test-bucket")):
+        payload = play_by_play.get_play_by_play(123, mark_index=False)
+
+    assert payload == {"plays": []}
+    assert not called["client"]
+
+
+def test_get_play_by_play_marks_index(monkeypatch):
+    calls = []
+
+    def fake_mark(bucket, *, date, game_id, away=None, home=None, artifact, exists):
+        calls.append((bucket, date, game_id, away, home, artifact, exists))
+
+    class DummyGameCenter:
+        def play_by_play(self, game_id):
+            return {
+                "plays": [],
+                "gameDate": "2025-04-25T23:00:00Z",
+                "awayTeam": {"abbrev": "COL"},
+                "homeTeam": {"abbrev": "MTL"},
+            }
+
+    class DummyClient:
+        def __init__(self):
+            self.game_center = DummyGameCenter()
+
+    monkeypatch.setattr(play_by_play, "mark_artifact", fake_mark)
+    monkeypatch.setattr(play_by_play, "NHLClient", DummyClient)
+    monkeypatch.setattr(play_by_play, "check_file_exists", lambda *args, **kwargs: False)
+    monkeypatch.setattr(play_by_play, "upload_json", lambda *args, **kwargs: None)
+
+    with config.override_settings(config.Settings(gcs_bucket_name="bucket")):
+        play_by_play.get_play_by_play(456, mark_index=True)
+
+    assert calls
+    bucket, date, game_id, away, home, artifact, exists = calls[-1]
+    assert bucket == "bucket"
+    assert date == "2025-04-25"
+    assert game_id == 456
+    assert away == "COL"
+    assert home == "MTL"
+    assert artifact == "raw_pbp"
+    assert exists is True

--- a/tests/test_schedule_index.py
+++ b/tests/test_schedule_index.py
@@ -1,0 +1,47 @@
+import config
+from data_fetch import schedule
+
+
+class DummyScheduleService:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def get_schedule(self, *, date):
+        return self._payload
+
+
+class DummyClient:
+    def __init__(self, payload):
+        self.schedule = DummyScheduleService(payload)
+
+
+def test_get_schedule_seeds_index(monkeypatch):
+    payload = {
+        "games": [
+            {
+                "id": 1,
+                "season": "20242025",
+                "gameType": "R",
+                "homeTeam": {"abbrev": "MTL", "score": 3},
+                "awayTeam": {"abbrev": "COL", "score": 2},
+                "winningGoalScorer": {"playerId": 42},
+            }
+        ]
+    }
+
+    calls = []
+
+    def fake_mark(bucket, *, date, game_id, away=None, home=None, artifact, exists):
+        calls.append((bucket, date, game_id, away, home, artifact, exists))
+
+    monkeypatch.setattr(schedule, "mark_artifact", fake_mark)
+    monkeypatch.setattr(schedule, "NHLClient", lambda: DummyClient(payload))
+
+    with config.override_settings(config.Settings(gcs_bucket_name="bucket")):
+        games = schedule.get_schedule("2025-04-25", mark_index=True)
+
+    assert len(games) == 1
+    assert calls  # raw_pbp and raw_story entries
+    artifacts = {(artifact, exists) for _, _, _, _, _, artifact, exists in calls}
+    assert ("raw_pbp", False) in artifacts
+    assert ("raw_story", False) in artifacts

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,77 @@
+import pytest
+
+from gcp_ingestion import (
+    check_file_exists,
+    download_json,
+    download_text,
+    override_storage_client,
+    reset_storage_client,
+    upload_json,
+    upload_text,
+)
+
+
+class FakeBlob:
+    def __init__(self, name: str, store: dict[str, dict]):
+        self.name = name
+        self._store = store
+        self._meta = store.setdefault(name, {})
+
+    def exists(self) -> bool:
+        return "data" in self._meta
+
+    def download_as_text(self) -> str:
+        if "data" not in self._meta:
+            raise FileNotFoundError(self.name)
+        return self._meta["data"]
+
+    def upload_from_string(self, *, data: str, content_type: str) -> None:
+        self._meta["data"] = data
+        self._meta["content_type"] = content_type
+
+
+class FakeBucket:
+    def __init__(self) -> None:
+        self._store: dict[str, dict] = {}
+
+    def blob(self, name: str) -> FakeBlob:
+        return FakeBlob(name, self._store)
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.buckets: dict[str, FakeBucket] = {}
+
+    def bucket(self, name: str) -> FakeBucket:
+        return self.buckets.setdefault(name, FakeBucket())
+
+
+@pytest.fixture
+def fake_client():
+    client = FakeClient()
+    with override_storage_client(client):
+        yield client
+    reset_storage_client()
+
+
+def test_upload_and_download_json(fake_client):
+    bucket = "bucket"
+    blob = "path.json"
+
+    upload_json(bucket, blob, {"hello": "world"})
+
+    assert check_file_exists(bucket, blob)
+    assert download_json(bucket, blob) == {"hello": "world"}
+
+
+def test_upload_and_download_text(fake_client):
+    bucket = "bucket"
+    blob = "note.txt"
+
+    upload_text(bucket, blob, "hi", content_type="text/plain")
+
+    assert download_text(bucket, blob) == "hi"
+
+
+def test_missing_blob_returns_false(fake_client):
+    assert not check_file_exists("bucket", "missing.txt")


### PR DESCRIPTION
## Summary
- centralize runtime configuration and update ingestion modules to use a shared settings helper
- make the GCS storage client injectable with structured logging across fetch and summary flows
- expose a programmatic summary entry point and add tests covering cache hits and schedule indexing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6082a126c832b864b902e39163d87