### PR TITLE
Restore direct nhlpy client usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openai
 requests
 python-dotenv
-nhlpy
+nhl-api-py
 google-cloud-storage


### PR DESCRIPTION
## Summary
- point schedule, play-by-play, and game story fetchers back to nhlpy's built-in NHLClient
- declare the correct nhl-api-py package in the requirements list now that the shim is gone

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e60b0c8b9c832bba65ed58ba6a45ca