### PR TITLE
Lazily initialize OpenAI client for AI summaries

### DIFF
--- a/engine/ai_summary.py
+++ b/engine/ai_summary.py
@@ -11,11 +11,15 @@ from openai import OpenAI
 
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "prompts"
 
-load_dotenv()
-api_key = getenv("OPENAI_API_KEY")
-if not api_key:
-    raise RuntimeError("Missing OPENAI_API_KEY environment variable")
-client = OpenAI(api_key=api_key)
+
+def _get_client() -> OpenAI:
+    """Create an OpenAI client after validating environment configuration."""
+    load_dotenv()
+    api_key = getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing OPENAI_API_KEY environment variable")
+    return OpenAI(api_key=api_key)
+
 
 def _load_template(name: str) -> str:
     """Load a text template from the prompts directory."""
@@ -41,7 +45,7 @@ def generate_ai_summary(play_by_play: Dict, game_story: Dict) -> str:
     )
 
     try:
-        response = client.responses.create(
+        response = _get_client().responses.create(
             model="gpt-5-nano",
             instructions="Talk like The Hockey Guy.",
             input=populated,


### PR DESCRIPTION
### Motivation

- Prevent module import from failing when `OPENAI_API_KEY` is not present by avoiding eager environment validation.
- Delay loading of `.env` and client creation until an AI summary is actually requested to reduce startup side effects.
- Make `engine/ai_summary.py` safe to import in contexts that do not need AI features.

### Description

- Add a helper function `_get_client()` that calls `load_dotenv()`, reads `getenv("OPENAI_API_KEY")`, validates it, and returns `OpenAI(api_key=...)`.
- Replace the former module-level `load_dotenv()`/`getenv()`/`OpenAI(...)` setup with lazy initialization and call `_get_client().responses.create` inside `generate_ai_summary()`.
- Preserve the original exception message `Missing OPENAI_API_KEY environment variable` when the key is absent.
- Remove eager module-level variables that depended on environment variables in `engine/ai_summary.py`.

### Testing

- No automated tests were executed as part of this change.
- The modified file `engine/ai_summary.py` was linted and parsed during development for syntax correctness.
- Manual inspection verified that `generate_ai_summary()` now calls `_get_client()` before making the OpenAI request.
- Existing behavior and exception messages were preserved for missing API key scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3ae6c60c832bb94327111c062f02)