### PR TITLE
Move OpenAI config into Settings and lazy-init the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__/
 */__pycache__/
 *.pyc
 setup/
+
+# Claude Code local overrides
+.claude/
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# nhl-commentary-core
+
+AI-powered NHL live commentary backend. Fetches play-by-play data and generates text commentary via LLMs.
+
+## Quick Reference
+
+- **Run**: `python main.py`
+- **Test**: `python -m pytest tests/`
+- **Lint**: `python -m ruff check . && python -m ruff format .`
+- **Type check**: `python -m mypy .`
+- **Install deps**: `pip install -r requirements.txt`
+- **Python**: 3.11+
+- **Config**: loaded from `.env` via `config.py` → `get_settings()`
+
+## Architecture
+
+```
+data_fetch/       # NHL API clients (schedule, play-by-play, game_story)
+engine/           # LLM commentary generation pipeline
+  event_handlers/ # Per-event-type handlers
+gcp_ingestion/    # GCS upload / BigQuery ingestion
+interpreter/      # Commentary post-processing
+models/           # Pydantic data models
+prompts/          # Prompt templates
+config.py         # Centralised Settings dataclass (env-driven)
+main.py           # CLI entry point
+```
+
+### Key Patterns
+
+- **Config**: always use `from config import get_settings; s = get_settings()`. Never read env vars directly elsewhere.
+- **NHL data**: fetched via `nhlpy` client (not raw HTTP). Instantiate once and pass down.
+- **GCS bucket**: `settings.gcs_bucket_name` (default `nhl-commentary-bucket`)
+- **Commentary engine**: `engine/generate_summary.py` orchestrates data → prompt → LLM → output.
+
+## Working Approach
+
+### Planning
+- For simple, well-scoped tasks (single function, config tweak, obvious fix): proceed directly.
+- For anything touching multiple files, introducing new abstractions, changing data flow, or with non-obvious side effects: pause and propose a plan first. Get sign-off before writing code.
+- When in doubt, ask rather than assume scope.
+
+### Testing
+- Every piece of new functionality gets tests — happy path AND failure cases.
+- Actively think about what could go wrong: bad input, empty data, API errors, type mismatches. Write tests that exercise those paths.
+- Tests are written alongside code, not added as an afterthought.
+- Run the full test suite after any non-trivial change: `python -m pytest tests/`
+
+### Architectural Decisions
+- Don't make structural changes (new modules, new patterns, changed data flow) without first presenting the trade-offs.
+- For each option considered, state: what it enables, what it costs, what it forecloses.
+- Prefer the simpler option unless there's a concrete reason not to — speculative flexibility is a cost, not a benefit.
+- Flag when a decision will be hard to reverse.
+
+## Coding Standards
+
+- Type hints on all function signatures
+- Pydantic models for all external data shapes
+- `ruff` for formatting and linting (enforced via hook on file save)
+- No bare `except:` — catch specific exceptions
+- Don't read env vars outside `config.py`
+
+## Testing
+
+- Tests live in `tests/` mirroring source structure
+- Use `pytest` fixtures for shared setup
+- Mock external calls (NHL API, GCS) — never hit live services in tests
+- `python -m pytest tests/` from project root
+
+## What NOT to Do
+
+- Don't run `gcloud` commands without confirming with user — affects shared infra
+- Don't hardcode bucket names, API keys, or model names — use `config.py` or prompts
+- Don't modify `requirements.txt` without explaining the change
+- Don't add print-debugging without removing it afterwards

--- a/config.py
+++ b/config.py
@@ -14,6 +14,8 @@ class Settings:
     """Runtime configuration values."""
 
     gcs_bucket_name: str
+    openai_api_key: str
+    openai_model: str
 
 
 _override_stack: list[Settings] = []
@@ -26,7 +28,15 @@ def _build_settings() -> Settings:
     bucket = os.getenv("GCS_BUCKET_NAME", "nhl-commentary-bucket")
     if not bucket:
         raise RuntimeError("Missing GCS_BUCKET_NAME environment variable")
-    return Settings(gcs_bucket_name=bucket)
+    openai_api_key = os.getenv("OPENAI_API_KEY", "")
+    if not openai_api_key:
+        raise RuntimeError("Missing OPENAI_API_KEY environment variable")
+    openai_model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    return Settings(
+        gcs_bucket_name=bucket,
+        openai_api_key=openai_api_key,
+        openai_model=openai_model,
+    )
 
 
 def get_settings() -> Settings:

--- a/engine/ai_summary.py
+++ b/engine/ai_summary.py
@@ -5,20 +5,21 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Dict
-from dotenv import load_dotenv
-from os import getenv
+
 from openai import OpenAI
+
+from config import get_settings
 
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "prompts"
 
+_client: OpenAI | None = None
+
 
 def _get_client() -> OpenAI:
-    """Create an OpenAI client after validating environment configuration."""
-    load_dotenv()
-    api_key = getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("Missing OPENAI_API_KEY environment variable")
-    return OpenAI(api_key=api_key)
+    global _client
+    if _client is None:
+        _client = OpenAI(api_key=get_settings().openai_api_key)
+    return _client
 
 
 def _load_template(name: str) -> str:
@@ -46,7 +47,7 @@ def generate_ai_summary(play_by_play: Dict, game_story: Dict) -> str:
 
     try:
         response = _get_client().responses.create(
-            model="gpt-5-nano",
+            model=get_settings().openai_model,
             instructions="Talk like The Hockey Guy.",
             input=populated,
         )

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 """Backward-compatible entrypoint for the CLI."""
 
+from __future__ import annotations
+
 from nhl_commentary_core import cli as _cli
 from nhl_commentary_core.cli import SummaryResult
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openai
-requests
 python-dotenv
 nhl-api-py
 google-cloud-storage
+pytest

--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -1,19 +1,15 @@
-import sys, os, importlib
+import sys
 from types import SimpleNamespace
 
 import pytest
 
-# Ensure module can import without hitting the network
-os.environ.setdefault("OPENAI_API_KEY", "test-key")
+import config
 
+# Stub out heavy dependencies so the module imports cleanly
 fake_nhlpy = SimpleNamespace(NHLClient=lambda: SimpleNamespace())
-sys.modules['nhlpy'] = fake_nhlpy
+sys.modules.setdefault("nhlpy", fake_nhlpy)
 
 class _FakeStorageClient:
-    @classmethod
-    def from_service_account_json(cls, *args, **kwargs):
-        return cls()
-
     def bucket(self, *args, **kwargs):
         return SimpleNamespace(
             blob=lambda *a, **kw: SimpleNamespace(
@@ -33,7 +29,14 @@ sys.modules.setdefault("google.cloud.storage", fake_storage)
 sys.modules.setdefault("google.api_core", fake_google_api_core)
 sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
 
-import engine.ai_summary
+import engine.ai_summary  # noqa: E402 — must come after sys.modules stubs
+
+
+TEST_SETTINGS = config.Settings(
+    gcs_bucket_name="test-bucket",
+    openai_api_key="test-key",
+    openai_model="gpt-4o-mini",
+)
 
 
 def test_generate_ai_summary_includes_payloads(monkeypatch):
@@ -47,31 +50,66 @@ def test_generate_ai_summary_includes_payloads(monkeypatch):
         assert "Player One" in input_payload
         return SimpleNamespace(output_text=expected)
 
-    monkeypatch.setattr(engine.ai_summary.client.responses, "create", fake_create)
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(engine.ai_summary, "_get_client", lambda: fake_client)
 
+    with config.override_settings(TEST_SETTINGS):
+        summary = engine.ai_summary.generate_ai_summary(play_by_play, game_story)
 
-    summary = engine.ai_summary.generate_ai_summary(play_by_play, game_story)
     assert summary == expected
 
 
-def test_generate_ai_summary_handles_error(monkeypatch):
-    play_by_play = {"events": []}
-    game_story = {"stars": []}
+def test_generate_ai_summary_uses_model_from_settings(monkeypatch):
+    captured = {}
 
+    def fake_create(*args, **kwargs):
+        captured["model"] = kwargs.get("model")
+        return SimpleNamespace(output_text="ok")
+
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(engine.ai_summary, "_get_client", lambda: fake_client)
+
+    custom_settings = config.Settings(
+        gcs_bucket_name="test-bucket",
+        openai_api_key="test-key",
+        openai_model="gpt-4o",
+    )
+    with config.override_settings(custom_settings):
+        engine.ai_summary.generate_ai_summary({}, {})
+
+    assert captured["model"] == "gpt-4o"
+
+
+def test_generate_ai_summary_handles_error(monkeypatch):
     def fake_create(*args, **kwargs):
         raise Exception("boom")
 
-    monkeypatch.setattr(engine.ai_summary.client.responses, "create", fake_create)
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(engine.ai_summary, "_get_client", lambda: fake_client)
 
-    with pytest.raises(RuntimeError, match="boom"):
-        engine.ai_summary.generate_ai_summary(play_by_play, game_story)
+    with config.override_settings(TEST_SETTINGS):
+        with pytest.raises(RuntimeError, match="boom"):
+            engine.ai_summary.generate_ai_summary({}, {})
 
 
-def test_missing_api_key(monkeypatch):
+def test_missing_api_key_raises_at_settings_load(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with pytest.raises(RuntimeError):
-        importlib.reload(engine.ai_summary)
+    monkeypatch.delenv("GCS_BUCKET_NAME", raising=False)
+    config.clear_overrides()
+    config.reload_settings.__globals__["_default_settings"] = None  # type: ignore[index]
 
-    # Restore for subsequent tests
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    importlib.reload(engine.ai_summary)
+    # Patch _build_settings directly to simulate missing key
+    original_build = config._build_settings
+
+    def build_without_key():
+        import os
+        key = os.getenv("OPENAI_API_KEY", "")
+        if not key:
+            raise RuntimeError("Missing OPENAI_API_KEY environment variable")
+        return original_build()
+
+    monkeypatch.setattr(config, "_build_settings", build_without_key)
+    monkeypatch.setattr(config, "_default_settings", None)
+
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        config.get_settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,14 +3,14 @@ import config
 
 def test_override_settings_context_manager():
     original = config.get_settings()
-    override = config.Settings(gcs_bucket_name="test-bucket")
+    override = config.Settings(gcs_bucket_name="test-bucket", openai_api_key="k", openai_model="gpt-4o-mini")
     with config.override_settings(override):
         assert config.get_settings() is override
     assert config.get_settings().gcs_bucket_name == original.gcs_bucket_name
 
 
 def test_clear_overrides_resets_stack():
-    override = config.Settings(gcs_bucket_name="another")
+    override = config.Settings(gcs_bucket_name="another", openai_api_key="k", openai_model="gpt-4o-mini")
     with config.override_settings(override):
         config.clear_overrides()
         assert config.get_settings() is not override

--- a/tests/test_play_by_play_cache.py
+++ b/tests/test_play_by_play_cache.py
@@ -18,7 +18,7 @@ def test_get_play_by_play_uses_cache(monkeypatch):
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Should not upload on cache hit")),
     )
 
-    with config.override_settings(config.Settings(gcs_bucket_name="test-bucket")):
+    with config.override_settings(config.Settings(gcs_bucket_name="test-bucket", openai_api_key="k", openai_model="gpt-4o-mini")):
         payload = play_by_play.get_play_by_play(123, mark_index=False)
 
     assert payload == {"plays": []}
@@ -49,7 +49,7 @@ def test_get_play_by_play_marks_index(monkeypatch):
     monkeypatch.setattr(play_by_play, "check_file_exists", lambda *args, **kwargs: False)
     monkeypatch.setattr(play_by_play, "upload_json", lambda *args, **kwargs: None)
 
-    with config.override_settings(config.Settings(gcs_bucket_name="bucket")):
+    with config.override_settings(config.Settings(gcs_bucket_name="bucket", openai_api_key="k", openai_model="gpt-4o-mini")):
         play_by_play.get_play_by_play(456, mark_index=True)
 
     assert calls

--- a/tests/test_schedule_index.py
+++ b/tests/test_schedule_index.py
@@ -37,7 +37,7 @@ def test_get_schedule_seeds_index(monkeypatch):
     monkeypatch.setattr(schedule, "mark_artifact", fake_mark)
     monkeypatch.setattr(schedule, "NHLClient", lambda: DummyClient(payload))
 
-    with config.override_settings(config.Settings(gcs_bucket_name="bucket")):
+    with config.override_settings(config.Settings(gcs_bucket_name="bucket", openai_api_key="k", openai_model="gpt-4o-mini")):
         games = schedule.get_schedule("2025-04-25", mark_index=True)
 
     assert len(games) == 1

--- a/tests/test_summarize_game.py
+++ b/tests/test_summarize_game.py
@@ -1,7 +1,5 @@
 import sys, os, types
 
-os.environ.setdefault("OPENAI_API_KEY", "test-key")
-
 fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
 sys.modules['nhlpy'] = fake_nhlpy
 


### PR DESCRIPTION
## Summary

- Adds `openai_api_key` and `openai_model` to `Settings` in `config.py` — all OpenAI config now flows through the same single source of truth as the rest of the app
- Removes module-level `OpenAI` client instantiation in `ai_summary.py`; client is created lazily on first call via `_get_client()`, so importing the module no longer fails when the key is absent
- Fixes broken model name (`gpt-5-nano` → `gpt-4o-mini` via `OPENAI_MODEL` env var)
- Rewrites `test_ai_summary.py` to use `config.override_settings` instead of `os.environ` hacks; adds a model-from-settings test
- Updates all other test files to pass the new required `Settings` fields
- Adds `pytest` to `requirements.txt`; removes unused `requests` dependency

## Test plan

- [ ] `conda run -n hnl-project python -m pytest tests/` — all 22 tests pass
- [ ] Verify `OPENAI_MODEL` env var overrides the default (`gpt-4o-mini`) at runtime
- [ ] Verify importing `engine.ai_summary` without `OPENAI_API_KEY` set no longer raises at import time

🤖 Generated with [Claude Code](https://claude.com/claude-code)