### PR TITLE
Add NHL editorial fetch and inject into AI summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ setup/
 # Claude Code local overrides
 .claude/
 CLAUDE.local.md
+
+# Local planning / roadmap (not tracked in git)
+.plan/

--- a/data_fetch/editorial.py
+++ b/data_fetch/editorial.py
@@ -61,7 +61,7 @@ def _fetch_from_forge(game_id: int) -> Optional[Dict[str, Any]]:
         resp = httpx.get(index_url, timeout=_HTTPX_TIMEOUT, follow_redirects=True)
         resp.raise_for_status()
         index_data = resp.json()
-    except httpx.HTTPStatusError as exc:
+    except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
         raise EditorialFetchError(
             f"Forge DAPI index request failed for game {game_id}: {exc}"
         ) from exc
@@ -101,7 +101,7 @@ def _fetch_from_forge(game_id: int) -> Optional[Dict[str, Any]]:
         resp2 = httpx.get(story_url, timeout=_HTTPX_TIMEOUT, follow_redirects=True)
         resp2.raise_for_status()
         story_data = resp2.json()
-    except httpx.HTTPStatusError as exc:
+    except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
         raise EditorialFetchError(
             f"Forge DAPI story request failed for game {game_id}: {exc}"
         ) from exc

--- a/data_fetch/editorial.py
+++ b/data_fetch/editorial.py
@@ -1,0 +1,229 @@
+"""Fetch NHL editorial game recaps from the NHL Forge DAPI."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from config import get_settings
+from gcp_ingestion import check_file_exists, download_json, upload_json
+
+try:  # engine module may not be available in all runtimes
+    from engine.date_index import mark_artifact
+except Exception:  # pragma: no cover - optional dependency
+    mark_artifact = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+FORGE_INDEX_URL = (
+    "https://forge-dapi.d3.nhle.com/v2/content/en-us/stories"
+    "?context.slug=nhl&tags.slug=gameid-{game_id}&$limit=1"
+)
+FORGE_STORY_URL = "https://forge-dapi.d3.nhle.com{self_url}"
+
+EDITORIAL_BLOB = "raw/editorial/{game_id}.json"
+
+_HTTPX_TIMEOUT = 15.0
+
+
+class EditorialFetchError(Exception):
+    """Raised when fetching editorial content fails unexpectedly."""
+
+
+def _bucket_name() -> str:
+    return get_settings().gcs_bucket_name
+
+
+def _extract_body(story: Dict[str, Any]) -> str:
+    """Concatenate all markdown parts from a Forge DAPI story into plain text."""
+    parts = story.get("parts", [])
+    chunks: list[str] = []
+    for part in parts:
+        if isinstance(part, dict) and part.get("type") == "markdown":
+            content = part.get("content", "")
+            if content:
+                chunks.append(content.strip())
+    return "\n\n".join(chunks)
+
+
+def _fetch_from_forge(game_id: int) -> Optional[Dict[str, Any]]:
+    """Fetch editorial data from Forge DAPI. Returns None if no recap exists."""
+    try:
+        import httpx
+    except ImportError as exc:  # pragma: no cover
+        raise EditorialFetchError(
+            "httpx is required for editorial fetch. Run: pip install httpx"
+        ) from exc
+
+    # Step 1: search for story by game tag
+    index_url = FORGE_INDEX_URL.format(game_id=game_id)
+    try:
+        resp = httpx.get(index_url, timeout=_HTTPX_TIMEOUT, follow_redirects=True)
+        resp.raise_for_status()
+        index_data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        raise EditorialFetchError(
+            f"Forge DAPI index request failed for game {game_id}: {exc}"
+        ) from exc
+    except Exception as exc:
+        raise EditorialFetchError(
+            f"Failed to fetch editorial index for game {game_id}: {exc}"
+        ) from exc
+
+    items = index_data.get("items", [])
+    if not items:
+        logger.debug("No editorial found for game %s", game_id)
+        return None
+
+    item = items[0]
+    self_url: Optional[str] = item.get("selfUrl") or item.get("url")
+    if not self_url:
+        logger.debug("Editorial index item missing selfUrl for game %s", game_id)
+        return None
+
+    headline = item.get("headline", {})
+    if isinstance(headline, dict):
+        headline_text = headline.get("default", "")
+    else:
+        headline_text = str(headline)
+
+    summary_field = item.get("summary", {})
+    if isinstance(summary_field, dict):
+        summary_text = summary_field.get("default", "")
+    else:
+        summary_text = str(summary_field)
+
+    content_date = item.get("contentDate") or item.get("date", "")
+
+    # Step 2: fetch the full story for the body text
+    story_url = FORGE_STORY_URL.format(self_url=self_url)
+    try:
+        resp2 = httpx.get(story_url, timeout=_HTTPX_TIMEOUT, follow_redirects=True)
+        resp2.raise_for_status()
+        story_data = resp2.json()
+    except httpx.HTTPStatusError as exc:
+        raise EditorialFetchError(
+            f"Forge DAPI story request failed for game {game_id}: {exc}"
+        ) from exc
+    except Exception as exc:
+        raise EditorialFetchError(
+            f"Failed to fetch editorial story for game {game_id}: {exc}"
+        ) from exc
+
+    body = _extract_body(story_data)
+
+    return {
+        "game_id": game_id,
+        "headline": headline_text,
+        "summary": summary_text,
+        "body": body,
+        "self_url": self_url,
+        "content_date": content_date,
+    }
+
+
+def _maybe_mark_index(
+    *,
+    game_id: int,
+    date: Optional[str],
+    away_abbr: Optional[str],
+    home_abbr: Optional[str],
+    mark: bool,
+) -> None:
+    """Best-effort update of the date index for raw_editorial."""
+    if not mark or not date or not mark_artifact:
+        return
+    try:
+        mark_artifact(
+            _bucket_name(),
+            date=date,
+            game_id=game_id,
+            away=away_abbr,
+            home=home_abbr,
+            artifact="raw_editorial",
+            exists=True,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to mark raw_editorial index for game %s on %s",
+            game_id,
+            date,
+            exc_info=True,
+        )
+
+
+def get_editorial(
+    game_id: int,
+    *,
+    force_refresh: bool = False,
+    date: Optional[str] = None,
+    away_abbr: Optional[str] = None,
+    home_abbr: Optional[str] = None,
+    mark_index: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """Fetch the editorial game recap for an NHL game, using GCS as a cache.
+
+    Returns None if no editorial recap has been published yet for the game.
+    Raises EditorialFetchError on unexpected HTTP or parsing failures.
+
+    Args:
+        game_id: Unique NHL game identifier.
+        force_refresh: Bypass cache and fetch from Forge DAPI.
+        date: YYYY-MM-DD for index marking (optional).
+        away_abbr: Away team abbreviation for index (optional).
+        home_abbr: Home team abbreviation for index (optional).
+        mark_index: When True, mark 'raw_editorial' in the date index.
+
+    Returns:
+        Dict with keys: game_id, headline, summary, body, self_url, content_date.
+        Or None if no editorial exists yet.
+
+    Raises:
+        EditorialFetchError: On unexpected fetch or parsing failures.
+    """
+    blob_path = EDITORIAL_BLOB.format(game_id=game_id)
+    bucket = _bucket_name()
+
+    # 1) Cache hit
+    if not force_refresh and check_file_exists(bucket, blob_path):
+        try:
+            cached = download_json(bucket, blob_path)
+            if isinstance(cached, dict):
+                _maybe_mark_index(
+                    game_id=game_id,
+                    date=date,
+                    away_abbr=away_abbr,
+                    home_abbr=home_abbr,
+                    mark=mark_index,
+                )
+                return cached
+        except Exception:
+            pass  # Fall through to live fetch on cache read error
+
+    # 2) Fetch from Forge DAPI
+    editorial = _fetch_from_forge(game_id)
+
+    if editorial is None:
+        # No recap published yet — not an error, don't cache the absence
+        return None
+
+    # 3) Best-effort cache write
+    try:
+        upload_json(bucket, blob_path, editorial)
+    except Exception:
+        logger.warning(
+            "Failed to upload editorial cache for game %s", game_id, exc_info=True
+        )
+
+    _maybe_mark_index(
+        game_id=game_id,
+        date=date,
+        away_abbr=away_abbr,
+        home_abbr=home_abbr,
+        mark=mark_index,
+    )
+
+    return editorial
+
+
+__all__ = ["get_editorial", "EditorialFetchError"]

--- a/engine/ai_summary.py
+++ b/engine/ai_summary.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from openai import OpenAI
 
@@ -28,21 +28,34 @@ def _load_template(name: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def generate_ai_summary(play_by_play: Dict, game_story: Dict) -> str:
+def generate_ai_summary(
+    play_by_play: Dict,
+    game_story: Dict,
+    editorial: Optional[Dict] = None,
+) -> str:
     """Generate a natural language summary for a game.
 
     Args:
         play_by_play (Dict): Structured play-by-play event data for the game.
         game_story (Dict): Additional narrative data for the game, including
             stars and statistics.
+        editorial (Dict, optional): NHL.com editorial recap with headline,
+            summary, and full body text. When provided, enriches the AI prompt
+            with narrative context (game significance, player quotes, milestones).
 
     Returns:
         str: Summary produced by the AI model.
     """
     template = _load_template("game_summary.txt")
+    editorial_text = (
+        f"{editorial.get('headline', '')}\n\n{editorial.get('body', '')}".strip()
+        if editorial
+        else "No editorial recap available."
+    )
     populated = template.format(
         play_by_play=json.dumps(play_by_play, indent=2),
         game_story=json.dumps(game_story, indent=2),
+        editorial=editorial_text,
     )
 
     try:

--- a/engine/summarize_game.py
+++ b/engine/summarize_game.py
@@ -1,14 +1,18 @@
 """High-level game summarization utilities."""
+import logging
 from typing import Optional
 from .process_game import process_game_events
 from .ai_summary import generate_ai_summary
-from data_fetch.play_by_play import get_play_by_play 
+from data_fetch.play_by_play import get_play_by_play
 from data_fetch.game_story import get_game_story
+from data_fetch.editorial import get_editorial, EditorialFetchError
 from .summaries import (
     get_or_build_stats_summary,
     save_ai_summary,
     load_ai_summary,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def summarize_game(game_id: int, date: Optional[str] = None, use_ai: bool = True) -> str:
@@ -29,10 +33,19 @@ def summarize_game(game_id: int, date: Optional[str] = None, use_ai: bool = True
         if ai:
             return ai
 
-        # 2) If none exists, fetch pbp + story, generate, cache
+        # 2) If none exists, fetch pbp + story + editorial, generate, cache
         pbp = get_play_by_play(game_id)
         story = get_game_story(game_id)
-        ai_summary = generate_ai_summary(pbp, story)
+
+        editorial = None
+        try:
+            editorial = get_editorial(game_id, date=date)
+        except EditorialFetchError:
+            logger.warning(
+                "Editorial fetch failed for game %s; proceeding without it", game_id, exc_info=True
+            )
+
+        ai_summary = generate_ai_summary(pbp, story, editorial=editorial)
         save_ai_summary(game_id=game_id, md=ai_summary, date=date)
         return ai_summary
 

--- a/prompts/game_summary.txt
+++ b/prompts/game_summary.txt
@@ -1,6 +1,8 @@
 You are an expert NHL commentator, analytical, yet very entertaining.
-Using the structured play-by-play and game story below, write a concise and engaging summary of the game.
+Using the structured play-by-play, game story, and editorial recap below, write a concise and engaging summary of the game.
 Use the tone of voice similar to The Hockey Guy from YouTube.
+
+Where available, incorporate context from the editorial recap: game significance, player milestones, rivalry notes, and key quotes.
 
 At the end of the report, provide some key match statistics (overall score, shots, penalties)
 and 3 stars of the game (with their respective stats).
@@ -10,6 +12,9 @@ Play-by-Play:
 
 Game Story:
 {game_story}
+
+Editorial Recap:
+{editorial}
 
 Summary:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ openai
 python-dotenv
 nhl-api-py
 google-cloud-storage
+httpx
 pytest

--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -59,6 +59,46 @@ def test_generate_ai_summary_includes_payloads(monkeypatch):
     assert summary == expected
 
 
+def test_generate_ai_summary_includes_editorial(monkeypatch):
+    """When editorial is provided, its headline and body appear in the prompt."""
+    editorial = {
+        "headline": "Historic rivalry clash",
+        "body": "The Habs and Leafs met for the 500th time.",
+        "summary": "A great game.",
+    }
+    captured = {}
+
+    def fake_create(*args, **kwargs):
+        captured["input"] = kwargs["input"]
+        return SimpleNamespace(output_text="ok")
+
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(engine.ai_summary, "_get_client", lambda: fake_client)
+
+    with config.override_settings(TEST_SETTINGS):
+        engine.ai_summary.generate_ai_summary({}, {}, editorial=editorial)
+
+    assert "Historic rivalry clash" in captured["input"]
+    assert "500th time" in captured["input"]
+
+
+def test_generate_ai_summary_no_editorial_uses_fallback(monkeypatch):
+    """When editorial is None, the prompt includes the fallback text."""
+    captured = {}
+
+    def fake_create(*args, **kwargs):
+        captured["input"] = kwargs["input"]
+        return SimpleNamespace(output_text="ok")
+
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(engine.ai_summary, "_get_client", lambda: fake_client)
+
+    with config.override_settings(TEST_SETTINGS):
+        engine.ai_summary.generate_ai_summary({}, {}, editorial=None)
+
+    assert "No editorial recap available." in captured["input"]
+
+
 def test_generate_ai_summary_uses_model_from_settings(monkeypatch):
     captured = {}
 

--- a/tests/test_editorial.py
+++ b/tests/test_editorial.py
@@ -283,3 +283,63 @@ def test_extract_body_concatenates_markdown_parts():
 def test_extract_body_empty_parts():
     assert editorial_mod._extract_body({}) == ""
     assert editorial_mod._extract_body({"parts": []}) == ""
+
+
+def test_http_error_on_index_raises_editorial_fetch_error(monkeypatch):
+    """An HTTP error from the Forge index endpoint raises EditorialFetchError."""
+    fake_gcs = _make_fake_gcs(exists=False)
+
+    class FakeHTTPStatusError(Exception):
+        pass
+
+    class FakeTimeoutException(Exception):
+        pass
+
+    def fake_get(url, *, timeout, follow_redirects=True):
+        raise FakeHTTPStatusError("404 Not Found")
+
+    fake_httpx = SimpleNamespace(
+        get=fake_get,
+        HTTPStatusError=FakeHTTPStatusError,
+        TimeoutException=FakeTimeoutException,
+    )
+
+    monkeypatch.setattr(editorial_mod, "check_file_exists", fake_gcs.check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", fake_gcs.download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", fake_gcs.upload_json)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", lambda *a, **kw: None)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    with config.override_settings(TEST_SETTINGS):
+        with pytest.raises(editorial_mod.EditorialFetchError, match="404"):
+            editorial_mod.get_editorial(12345)
+
+
+def test_cache_read_error_falls_through_to_live_fetch(monkeypatch):
+    """A corrupt cache entry is ignored and the live Forge DAPI is called instead."""
+    fake_httpx = _make_httpx_mock(FORGE_INDEX_RESPONSE, FORGE_STORY_RESPONSE)
+    upload_calls = []
+
+    def check_file_exists(bucket, path):
+        return True  # Cache appears to exist
+
+    def download_json(bucket, path):
+        raise RuntimeError("corrupt blob")  # Cache read fails
+
+    def upload_json(bucket, path, data):
+        upload_calls.append(data)
+
+    monkeypatch.setattr(editorial_mod, "check_file_exists", check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", upload_json)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", lambda *a, **kw: None)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    with config.override_settings(TEST_SETTINGS):
+        result = editorial_mod.get_editorial(12345)
+
+    # Should have fallen through to live fetch and returned real data
+    assert result is not None
+    assert result["headline"] == "Great game headline"
+    # And re-cached it
+    assert len(upload_calls) == 1

--- a/tests/test_editorial.py
+++ b/tests/test_editorial.py
@@ -1,0 +1,285 @@
+"""Tests for data_fetch.editorial."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import config
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies before any project imports
+# ---------------------------------------------------------------------------
+
+fake_nhlpy = SimpleNamespace(NHLClient=lambda: SimpleNamespace())
+sys.modules.setdefault("nhlpy", fake_nhlpy)
+
+
+class _FakeStorageClient:
+    def bucket(self, *args, **kwargs):
+        return SimpleNamespace(
+            blob=lambda *a, **kw: SimpleNamespace(
+                exists=lambda: False,
+                download_as_text=lambda: "",
+                upload_from_string=lambda *a, **kw: None,
+            )
+        )
+
+
+fake_storage = SimpleNamespace(Client=_FakeStorageClient, Bucket=SimpleNamespace)
+fake_exceptions = SimpleNamespace(NotFound=Exception)
+fake_google_cloud = SimpleNamespace(storage=fake_storage)
+fake_google_api_core = SimpleNamespace(exceptions=fake_exceptions)
+sys.modules.setdefault("google", SimpleNamespace(cloud=fake_google_cloud, api_core=fake_google_api_core))
+sys.modules.setdefault("google.cloud", fake_google_cloud)
+sys.modules.setdefault("google.cloud.storage", fake_storage)
+sys.modules.setdefault("google.api_core", fake_google_api_core)
+sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
+
+import data_fetch.editorial as editorial_mod  # noqa: E402
+
+TEST_SETTINGS = config.Settings(
+    gcs_bucket_name="test-bucket",
+    openai_api_key="test-key",
+    openai_model="gpt-4o-mini",
+)
+
+FAKE_EDITORIAL = {
+    "game_id": 12345,
+    "headline": "Great game headline",
+    "summary": "Short summary here.",
+    "body": "Full recap body text.",
+    "self_url": "/v2/content/en-us/stories/nhl-great-game",
+    "content_date": "2025-04-25",
+}
+
+# Forge DAPI response shapes
+FORGE_INDEX_RESPONSE = {
+    "items": [
+        {
+            "selfUrl": "/v2/content/en-us/stories/nhl-great-game",
+            "headline": {"default": "Great game headline"},
+            "summary": {"default": "Short summary here."},
+            "contentDate": "2025-04-25",
+        }
+    ]
+}
+
+FORGE_STORY_RESPONSE = {
+    "parts": [
+        {"type": "markdown", "content": "Full recap body text."},
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_gcs(*, exists: bool, cached_value=None):
+    """Build a fake gcp_ingestion module."""
+
+    def check_file_exists(bucket, path):
+        return exists
+
+    def download_json(bucket, path):
+        if cached_value is not None:
+            return cached_value
+        raise RuntimeError("No cached value")
+
+    upload_calls = []
+
+    def upload_json(bucket, path, data):
+        upload_calls.append((bucket, path, data))
+
+    fake = SimpleNamespace(
+        check_file_exists=check_file_exists,
+        download_json=download_json,
+        upload_json=upload_json,
+        upload_calls=upload_calls,
+    )
+    return fake
+
+
+def _make_httpx_mock(index_response, story_response=None, raise_on_index=False, raise_on_story=False):
+    """Return a fake httpx module."""
+
+    class FakeResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    class FakeHTTPStatusError(Exception):
+        pass
+
+    call_log = []
+
+    def fake_get(url, *, timeout, follow_redirects=True):
+        call_log.append(url)
+        is_index = "tags.slug" in url
+        if is_index:
+            if raise_on_index:
+                raise FakeHTTPStatusError("404")
+            return FakeResponse(index_response)
+        else:
+            if raise_on_story:
+                raise FakeHTTPStatusError("500")
+            return FakeResponse(story_response or {})
+
+    fake_httpx = SimpleNamespace(
+        get=fake_get,
+        HTTPStatusError=FakeHTTPStatusError,
+        call_log=call_log,
+    )
+    return fake_httpx
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_returns_cached_value(monkeypatch):
+    """When GCS has a cached editorial, return it without hitting Forge DAPI."""
+    fake_gcs = _make_fake_gcs(exists=True, cached_value=FAKE_EDITORIAL)
+    monkeypatch.setattr(editorial_mod, "check_file_exists", fake_gcs.check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", fake_gcs.download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", fake_gcs.upload_json)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", lambda *a, **kw: None)
+
+    with config.override_settings(TEST_SETTINGS):
+        result = editorial_mod.get_editorial(12345)
+
+    assert result == FAKE_EDITORIAL
+
+
+def test_cache_miss_fetches_and_caches(monkeypatch):
+    """On cache miss, fetch from Forge DAPI and upload to GCS."""
+    fake_gcs = _make_fake_gcs(exists=False)
+    fake_httpx = _make_httpx_mock(FORGE_INDEX_RESPONSE, FORGE_STORY_RESPONSE)
+
+    monkeypatch.setattr(editorial_mod, "check_file_exists", fake_gcs.check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", fake_gcs.download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", fake_gcs.upload_json)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", lambda *a, **kw: None)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    with config.override_settings(TEST_SETTINGS):
+        result = editorial_mod.get_editorial(12345)
+
+    assert result is not None
+    assert result["headline"] == "Great game headline"
+    assert result["body"] == "Full recap body text."
+    assert result["game_id"] == 12345
+    # Should have uploaded to GCS
+    assert len(fake_gcs.upload_calls) == 1
+
+
+def test_no_editorial_returns_none(monkeypatch):
+    """When Forge DAPI returns empty items, return None (not an error)."""
+    fake_gcs = _make_fake_gcs(exists=False)
+    empty_index = {"items": []}
+    fake_httpx = _make_httpx_mock(empty_index)
+
+    monkeypatch.setattr(editorial_mod, "check_file_exists", fake_gcs.check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", fake_gcs.download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", fake_gcs.upload_json)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", lambda *a, **kw: None)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    with config.override_settings(TEST_SETTINGS):
+        result = editorial_mod.get_editorial(99999)
+
+    assert result is None
+    # Should NOT have uploaded anything (no data to cache)
+    assert len(fake_gcs.upload_calls) == 0
+
+
+def test_gcs_upload_failure_logs_warning_and_returns_data(monkeypatch):
+    """GCS upload failure is a warning, not an exception; editorial is still returned."""
+    fake_gcs = _make_fake_gcs(exists=False)
+
+    def failing_upload(bucket, path, data):
+        raise RuntimeError("GCS unavailable")
+
+    fake_httpx = _make_httpx_mock(FORGE_INDEX_RESPONSE, FORGE_STORY_RESPONSE)
+
+    monkeypatch.setattr(editorial_mod, "check_file_exists", fake_gcs.check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", fake_gcs.download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", failing_upload)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", lambda *a, **kw: None)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    with config.override_settings(TEST_SETTINGS):
+        result = editorial_mod.get_editorial(12345)
+
+    # Data still returned despite GCS failure
+    assert result is not None
+    assert result["headline"] == "Great game headline"
+
+
+def test_mark_artifact_called_with_raw_editorial(monkeypatch):
+    """After a successful fetch, mark_artifact is called with artifact='raw_editorial'."""
+    fake_gcs = _make_fake_gcs(exists=False)
+    fake_httpx = _make_httpx_mock(FORGE_INDEX_RESPONSE, FORGE_STORY_RESPONSE)
+    mark_calls = []
+
+    def fake_mark(bucket, *, date, game_id, away, home, artifact, exists):
+        mark_calls.append({"artifact": artifact, "game_id": game_id, "date": date})
+
+    monkeypatch.setattr(editorial_mod, "check_file_exists", fake_gcs.check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", fake_gcs.download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", fake_gcs.upload_json)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", fake_mark)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    with config.override_settings(TEST_SETTINGS):
+        editorial_mod.get_editorial(12345, date="2025-04-25")
+
+    assert any(c["artifact"] == "raw_editorial" for c in mark_calls)
+    assert any(c["game_id"] == 12345 for c in mark_calls)
+
+
+def test_force_refresh_bypasses_cache(monkeypatch):
+    """force_refresh=True skips the GCS cache even when data is present."""
+    fake_gcs = _make_fake_gcs(exists=True, cached_value=FAKE_EDITORIAL)
+    fake_httpx = _make_httpx_mock(FORGE_INDEX_RESPONSE, FORGE_STORY_RESPONSE)
+
+    monkeypatch.setattr(editorial_mod, "check_file_exists", fake_gcs.check_file_exists)
+    monkeypatch.setattr(editorial_mod, "download_json", fake_gcs.download_json)
+    monkeypatch.setattr(editorial_mod, "upload_json", fake_gcs.upload_json)
+    monkeypatch.setattr(editorial_mod, "mark_artifact", lambda *a, **kw: None)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    with config.override_settings(TEST_SETTINGS):
+        result = editorial_mod.get_editorial(12345, force_refresh=True)
+
+    # Should have hit Forge DAPI (freshly fetched body from story mock)
+    assert result is not None
+    assert result["body"] == "Full recap body text."
+
+
+def test_extract_body_concatenates_markdown_parts():
+    """_extract_body joins markdown parts and ignores non-markdown ones."""
+    story = {
+        "parts": [
+            {"type": "markdown", "content": "Part one."},
+            {"type": "image", "content": "ignored"},
+            {"type": "markdown", "content": "Part two."},
+        ]
+    }
+    body = editorial_mod._extract_body(story)
+    assert "Part one." in body
+    assert "Part two." in body
+    assert "ignored" not in body
+
+
+def test_extract_body_empty_parts():
+    assert editorial_mod._extract_body({}) == ""
+    assert editorial_mod._extract_body({"parts": []}) == ""

--- a/tests/test_summarize_game.py
+++ b/tests/test_summarize_game.py
@@ -58,7 +58,7 @@ def test_summarize_game_ai(monkeypatch):
     def fake_get_or_build_stats_summary(game_id, events, date=None):
         raise AssertionError("Rule-based summary should not be called")
 
-    def fake_generate_ai_summary(play_by_play, game_story):
+    def fake_generate_ai_summary(play_by_play, game_story, editorial=None):
         assert play_by_play == ["event"]
         assert game_story == {"story": "data"}
         return "ai summary"
@@ -68,6 +68,7 @@ def test_summarize_game_ai(monkeypatch):
     monkeypatch.setattr("engine.summarize_game.generate_ai_summary", fake_generate_ai_summary)
     monkeypatch.setattr("engine.summarize_game.get_play_by_play", lambda game_id: ["event"])
     monkeypatch.setattr("engine.summarize_game.get_game_story", lambda game_id: {"story": "data"})
+    monkeypatch.setattr("engine.summarize_game.get_editorial", lambda game_id, **kw: None)
 
     summary = engine.summarize_game.summarize_game(2, use_ai=True)
     assert summary == "ai summary"


### PR DESCRIPTION
## Summary

- Adds `data_fetch/editorial.py` — fetches full narrative game recaps from the NHL Forge DAPI (`forge-dapi.d3.nhle.com`) in two steps (index lookup by game tag → full story detail). GCS-cached at `raw/editorial/{game_id}.json`. Returns `None` when no recap is published yet (not treated as an error).
- Extends `generate_ai_summary` with an optional `editorial` param; prompt template gains an `{editorial}` section with fallback text when unavailable.
- `summarize_game` fetches editorial and passes it to the AI path; falls back gracefully if the fetch raises.
- Adds `httpx` to requirements (cleaner API than urllib, async-compatible for the planned FastAPI layer).

## Test plan

- [ ] `python -m pytest tests/test_editorial.py tests/test_ai_summary.py tests/test_summarize_game.py -v` — all pass (32 total)
- [ ] Run against a real game to verify editorial context appears in the summary when a recap is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)