### PR TITLE
Add GameSummary model and batch processing

### DIFF
--- a/engine/batch.py
+++ b/engine/batch.py
@@ -1,0 +1,56 @@
+"""Batch game summarization for a full date."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from data_fetch.schedule import get_schedule
+from models.game_summary import GameSummary
+from .summarize_game import summarize_game
+
+logger = logging.getLogger(__name__)
+
+
+def summarize_date(
+    date: str,
+    *,
+    use_ai: bool = True,
+) -> List[GameSummary]:
+    """Summarize all games scheduled on a given date.
+
+    Games that fail are logged and skipped; the returned list contains only
+    successful summaries. Team and score fields are enriched from the schedule.
+
+    Args:
+        date: Game date in YYYY-MM-DD format.
+        use_ai: When True (default), use the AI summary path.
+
+    Returns:
+        List of GameSummary objects, one per successfully processed game.
+    """
+    schedule = get_schedule(date)
+    results: List[GameSummary] = []
+
+    for game in schedule:
+        try:
+            summary = summarize_game(game.game_id, date=date, use_ai=use_ai)
+            enriched = summary.model_copy(update={
+                "home_team": game.home_team,
+                "away_team": game.away_team,
+                "home_score": game.home_team_score,
+                "away_score": game.away_team_score,
+            })
+            results.append(enriched)
+        except Exception:
+            logger.warning(
+                "Failed to summarize game %s on %s; skipping",
+                game.game_id,
+                date,
+                exc_info=True,
+            )
+
+    return results
+
+
+__all__ = ["summarize_date"]

--- a/engine/summarize_game.py
+++ b/engine/summarize_game.py
@@ -1,6 +1,11 @@
 """High-level game summarization utilities."""
+from __future__ import annotations
+
 import logging
+from datetime import datetime, timezone
 from typing import Optional
+
+from models.game_summary import GameSummary
 from .process_game import process_game_events
 from .ai_summary import generate_ai_summary
 from data_fetch.play_by_play import get_play_by_play
@@ -15,25 +20,38 @@ from .summaries import (
 logger = logging.getLogger(__name__)
 
 
-def summarize_game(game_id: int, date: Optional[str] = None, use_ai: bool = True) -> str:
-    """Return a summary for the specified game.
+def summarize_game(
+    game_id: int,
+    date: Optional[str] = None,
+    use_ai: bool = True,
+) -> GameSummary:
+    """Return a structured summary for the specified game.
 
     Args:
-        game_id (int): NHL game identifier.
-        date (str, optional): Game date in YYYY-MM-DD (for index marking).
-        use_ai (bool, optional): If True (default), AI summary is returned/cached.
-                                 If False, rule-based stats summary is returned/cached.
+        game_id: NHL game identifier.
+        date: Game date in YYYY-MM-DD (for GCS index marking).
+        use_ai: If True (default), AI summary is returned/cached.
+                If False, rule-based stats summary is returned/cached.
 
     Returns:
-        str: Generated or cached summary text.
+        GameSummary with summary_markdown and metadata.
     """
-    if use_ai:
-        # 1) Try loading AI summary from GCS
-        ai = load_ai_summary(game_id=game_id)
-        if ai:
-            return ai
+    now = datetime.now(timezone.utc)
 
-        # 2) If none exists, fetch pbp + story + editorial, generate, cache
+    if use_ai:
+        # 1) Try loading from GCS cache
+        cached_text = load_ai_summary(game_id=game_id)
+        if cached_text:
+            return GameSummary(
+                game_id=game_id,
+                date=date,
+                summary_markdown=cached_text,
+                summary_type="ai",
+                generated_at=now,
+                cached=True,
+            )
+
+        # 2) Fetch all data, generate, cache
         pbp = get_play_by_play(game_id)
         story = get_game_story(game_id)
 
@@ -42,16 +60,37 @@ def summarize_game(game_id: int, date: Optional[str] = None, use_ai: bool = True
             editorial = get_editorial(game_id, date=date)
         except EditorialFetchError:
             logger.warning(
-                "Editorial fetch failed for game %s; proceeding without it", game_id, exc_info=True
+                "Editorial fetch failed for game %s; proceeding without it",
+                game_id,
+                exc_info=True,
             )
 
-        ai_summary = generate_ai_summary(pbp, story, editorial=editorial)
-        save_ai_summary(game_id=game_id, md=ai_summary, date=date)
-        return ai_summary
+        ai_text = generate_ai_summary(pbp, story, editorial=editorial)
+        save_ai_summary(game_id=game_id, md=ai_text, date=date)
 
-    # Stats (rule-based) summary: always use the cache wrapper
+        return GameSummary(
+            game_id=game_id,
+            date=date,
+            summary_markdown=ai_text,
+            summary_type="ai",
+            editorial_headline=editorial.get("headline") if editorial else None,
+            editorial_summary=editorial.get("summary") if editorial else None,
+            generated_at=now,
+            cached=False,
+        )
+
+    # Rule-based path
     events = process_game_events(game_id)
-    return get_or_build_stats_summary(game_id=game_id, events=events, date=date)
+    stats_text = get_or_build_stats_summary(game_id=game_id, events=events, date=date)
+
+    return GameSummary(
+        game_id=game_id,
+        date=date,
+        summary_markdown=stats_text,
+        summary_type="rule_based",
+        generated_at=now,
+        cached=False,
+    )
 
 
 __all__ = ["summarize_game"]

--- a/models/game_summary.py
+++ b/models/game_summary.py
@@ -1,0 +1,33 @@
+"""Structured output model for a summarised NHL game."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class GameSummary(BaseModel):
+    """Typed result returned by summarize_game and summarize_date.
+
+    team/score fields default to None because summarize_game only receives a
+    game_id. Callers that hold a GameSchedule (CLI, batch) enrich these fields
+    via model_copy(update={...}) after the fact.
+    """
+
+    game_id: int
+    date: Optional[str] = None          # YYYY-MM-DD
+    home_team: Optional[str] = None
+    away_team: Optional[str] = None
+    home_score: Optional[int] = None
+    away_score: Optional[int] = None
+    summary_markdown: str
+    summary_type: Literal["ai", "rule_based"]
+    editorial_headline: Optional[str] = None
+    editorial_summary: Optional[str] = None
+    generated_at: datetime
+    cached: bool
+
+
+__all__ = ["GameSummary"]

--- a/nhl_commentary_core/cli.py
+++ b/nhl_commentary_core/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 from dataclasses import dataclass
-from typing import Iterable, Optional  # noqa: F401 — Optional used in function signatures
+from typing import Iterable, Optional
 
 try:  # pragma: no cover - optional dependency during testing
     from data_fetch.schedule import get_schedule as _get_schedule

--- a/nhl_commentary_core/cli.py
+++ b/nhl_commentary_core/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Iterable, Optional  # noqa: F401 — Optional used in function signatures
 
 try:  # pragma: no cover - optional dependency during testing
     from data_fetch.schedule import get_schedule as _get_schedule
@@ -17,6 +17,7 @@ try:  # pragma: no cover - optional dependency during testing
 except Exception:  # pragma: no cover - fallback when optional deps missing
     _summarize_game = None
 from models.game_schedule import GameSchedule
+from models.game_summary import GameSummary
 
 DEFAULT_DATE = "2025-04-01"  # Fallback date if user input is empty
 
@@ -29,7 +30,7 @@ class GameSelectionError(RuntimeError):
 
 @dataclass(frozen=True)
 class SummaryResult:
-    summary: Optional[str]
+    summary: GameSummary
     game: GameSchedule
 
 
@@ -143,8 +144,8 @@ def _interactive_flow(args: argparse.Namespace) -> None:
 
     game = result.game
     print(f"Processing Game ID: {game.game_id} ({game.home_team} vs {game.away_team})")
-    if result.summary:
-        print(result.summary)
+    if result.summary.summary_markdown:
+        print(result.summary.summary_markdown)
     else:
         print(f"⚠️ No events for game {game.game_id}")
 
@@ -177,8 +178,8 @@ def main(argv: Optional[list[str]] = None) -> None:
             logger.exception("Failed to summarize game")
             raise SystemExit(str(exc)) from exc
 
-        if result.summary:
-            print(result.summary)
+        if result.summary.summary_markdown:
+            print(result.summary.summary_markdown)
         else:
             print(f"⚠️ No events for game {result.game.game_id}")
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ python-dotenv
 nhl-api-py
 google-cloud-storage
 httpx
+pydantic
 pytest

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,123 @@
+"""Tests for engine.batch.summarize_date."""
+
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import config
+
+# Stub heavy deps before any project imports
+fake_nhlpy = SimpleNamespace(NHLClient=lambda: SimpleNamespace())
+sys.modules.setdefault("nhlpy", fake_nhlpy)
+
+class _FakeStorageClient:
+    def bucket(self, *a, **kw):
+        return SimpleNamespace(blob=lambda *a, **kw: SimpleNamespace(
+            exists=lambda: False,
+            download_as_text=lambda: "",
+            upload_from_string=lambda *a, **kw: None,
+        ))
+
+fake_storage = SimpleNamespace(Client=_FakeStorageClient, Bucket=SimpleNamespace)
+fake_exceptions = SimpleNamespace(NotFound=Exception)
+fake_google_cloud = SimpleNamespace(storage=fake_storage)
+fake_google_api_core = SimpleNamespace(exceptions=fake_exceptions)
+sys.modules.setdefault("google", SimpleNamespace(cloud=fake_google_cloud, api_core=fake_google_api_core))
+sys.modules.setdefault("google.cloud", fake_google_cloud)
+sys.modules.setdefault("google.cloud.storage", fake_storage)
+sys.modules.setdefault("google.api_core", fake_google_api_core)
+sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
+
+import engine.batch as batch_mod  # noqa: E402
+from models.game_schedule import GameSchedule
+from models.game_summary import GameSummary
+
+TEST_SETTINGS = config.Settings(
+    gcs_bucket_name="test-bucket",
+    openai_api_key="test-key",
+    openai_model="gpt-4o-mini",
+)
+
+NOW = datetime.now(timezone.utc)
+
+
+def _make_game(game_id: int, home: str = "MTL", away: str = "COL") -> GameSchedule:
+    return GameSchedule(
+        game_id=game_id,
+        season_id="20242025",
+        game_type="R",
+        home_team=home,
+        home_team_score=3,
+        away_team=away,
+        away_team_score=2,
+        winning_goal_scorer_id=None,
+    )
+
+
+def _make_summary(game_id: int) -> GameSummary:
+    return GameSummary(
+        game_id=game_id,
+        summary_markdown=f"Summary for {game_id}",
+        summary_type="ai",
+        generated_at=NOW,
+        cached=False,
+    )
+
+
+def test_single_game_success(monkeypatch):
+    game = _make_game(100)
+    monkeypatch.setattr(batch_mod, "get_schedule", lambda date: [game])
+    monkeypatch.setattr(batch_mod, "summarize_game", lambda game_id, date, use_ai: _make_summary(game_id))
+
+    with config.override_settings(TEST_SETTINGS):
+        results = batch_mod.summarize_date("2025-04-25")
+
+    assert len(results) == 1
+    assert results[0].game_id == 100
+    # Enriched with schedule data
+    assert results[0].home_team == "MTL"
+    assert results[0].away_team == "COL"
+    assert results[0].home_score == 3
+    assert results[0].away_score == 2
+
+
+def test_multiple_games(monkeypatch):
+    games = [_make_game(1), _make_game(2), _make_game(3)]
+    monkeypatch.setattr(batch_mod, "get_schedule", lambda date: games)
+    monkeypatch.setattr(batch_mod, "summarize_game", lambda game_id, date, use_ai: _make_summary(game_id))
+
+    with config.override_settings(TEST_SETTINGS):
+        results = batch_mod.summarize_date("2025-04-25")
+
+    assert len(results) == 3
+    assert {r.game_id for r in results} == {1, 2, 3}
+
+
+def test_partial_failure_continues(monkeypatch):
+    """One failing game is skipped; others succeed."""
+    games = [_make_game(10), _make_game(11), _make_game(12)]
+
+    def fake_summarize(game_id, date, use_ai):
+        if game_id == 11:
+            raise RuntimeError("game 11 exploded")
+        return _make_summary(game_id)
+
+    monkeypatch.setattr(batch_mod, "get_schedule", lambda date: games)
+    monkeypatch.setattr(batch_mod, "summarize_game", fake_summarize)
+
+    with config.override_settings(TEST_SETTINGS):
+        results = batch_mod.summarize_date("2025-04-25")
+
+    assert len(results) == 2
+    assert {r.game_id for r in results} == {10, 12}
+
+
+def test_empty_schedule(monkeypatch):
+    monkeypatch.setattr(batch_mod, "get_schedule", lambda date: [])
+
+    with config.override_settings(TEST_SETTINGS):
+        results = batch_mod.summarize_date("2025-04-25")
+
+    assert results == []

--- a/tests/test_game_summary_model.py
+++ b/tests/test_game_summary_model.py
@@ -1,0 +1,73 @@
+"""Tests for models.game_summary.GameSummary."""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from models.game_summary import GameSummary
+
+NOW = datetime.now(timezone.utc)
+
+
+def _make(**kwargs) -> GameSummary:
+    defaults = dict(
+        game_id=2024020001,
+        summary_markdown="Great game.",
+        summary_type="ai",
+        generated_at=NOW,
+        cached=False,
+    )
+    defaults.update(kwargs)
+    return GameSummary(**defaults)
+
+
+def test_minimal_valid_model():
+    gs = _make()
+    assert gs.game_id == 2024020001
+    assert gs.summary_markdown == "Great game."
+    assert gs.home_team is None
+    assert gs.cached is False
+
+
+def test_full_model():
+    gs = _make(
+        date="2025-04-25",
+        home_team="MTL",
+        away_team="COL",
+        home_score=3,
+        away_score=2,
+        summary_type="rule_based",
+        editorial_headline="Habs win!",
+        editorial_summary="Short recap.",
+        cached=True,
+    )
+    assert gs.home_team == "MTL"
+    assert gs.home_score == 3
+    assert gs.editorial_headline == "Habs win!"
+    assert gs.summary_type == "rule_based"
+
+
+def test_json_round_trip():
+    gs = _make(date="2025-04-25", home_team="MTL", away_team="COL")
+    serialised = gs.model_dump_json()
+    restored = GameSummary.model_validate_json(serialised)
+    assert restored.game_id == gs.game_id
+    assert restored.home_team == gs.home_team
+    assert restored.generated_at == gs.generated_at
+
+
+def test_invalid_summary_type_raises():
+    with pytest.raises(ValidationError):
+        _make(summary_type="unknown")
+
+
+def test_model_copy_enrichment():
+    gs = _make()
+    assert gs.home_team is None
+    enriched = gs.model_copy(update={"home_team": "MTL", "away_team": "COL", "home_score": 3, "away_score": 2})
+    assert enriched.home_team == "MTL"
+    assert enriched.away_score == 2
+    # Original unchanged
+    assert gs.home_team is None

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -1,7 +1,9 @@
 import pytest
+from datetime import datetime, timezone
 
 import main
 from models.game_schedule import GameSchedule
+from models.game_summary import GameSummary
 
 
 def make_game(game_id: int) -> GameSchedule:
@@ -17,6 +19,16 @@ def make_game(game_id: int) -> GameSchedule:
     )
 
 
+def make_game_summary(game_id: int, markdown: str = "") -> GameSummary:
+    return GameSummary(
+        game_id=game_id,
+        summary_markdown=markdown or f"summary-{game_id}",
+        summary_type="rule_based",
+        generated_at=datetime.now(timezone.utc),
+        cached=False,
+    )
+
+
 def test_generate_summary_for_date_requires_game_id_for_multiple_games(monkeypatch):
     monkeypatch.setattr(main, "get_schedule", lambda date: [make_game(1), make_game(2)])
     with pytest.raises(main.GameSelectionError):
@@ -25,9 +37,10 @@ def test_generate_summary_for_date_requires_game_id_for_multiple_games(monkeypat
 
 def test_generate_summary_for_date_returns_summary(monkeypatch):
     monkeypatch.setattr(main, "get_schedule", lambda date: [make_game(99)])
-    monkeypatch.setattr(main, "summarize_game", lambda game_id, use_ai: f"summary-{game_id}-{use_ai}")
+    monkeypatch.setattr(main, "summarize_game",
+                        lambda game_id, use_ai: make_game_summary(game_id, f"summary-{game_id}-{use_ai}"))
     result = main.generate_summary_for_date("2025-04-25", use_ai=False)
-    assert result.summary == "summary-99-False"
+    assert result.summary.summary_markdown == "summary-99-False"
     assert result.game.game_id == 99
 
 

--- a/tests/test_summarize_game.py
+++ b/tests/test_summarize_game.py
@@ -1,4 +1,5 @@
 import sys, os, types
+from datetime import datetime, timezone
 
 fake_nhlpy = types.SimpleNamespace(NHLClient=lambda: types.SimpleNamespace())
 sys.modules['nhlpy'] = fake_nhlpy
@@ -28,6 +29,17 @@ sys.modules.setdefault("google.api_core", fake_google_api_core)
 sys.modules.setdefault("google.api_core.exceptions", fake_exceptions)
 
 import engine.summarize_game
+from models.game_summary import GameSummary
+
+
+def _make_summary(markdown: str = "test summary", summary_type: str = "rule_based") -> GameSummary:
+    return GameSummary(
+        game_id=1,
+        summary_markdown=markdown,
+        summary_type=summary_type,
+        generated_at=datetime.now(timezone.utc),
+        cached=False,
+    )
 
 
 def test_summarize_game_rule_based(monkeypatch):
@@ -46,29 +58,59 @@ def test_summarize_game_rule_based(monkeypatch):
     monkeypatch.setattr("engine.summarize_game.get_or_build_stats_summary", fake_get_or_build_stats_summary)
     monkeypatch.setattr("engine.summarize_game.generate_ai_summary", fake_generate_ai_summary)
 
-    summary = engine.summarize_game.summarize_game(1, use_ai=False)
-    assert summary == "rule summary"
+    result = engine.summarize_game.summarize_game(1, use_ai=False)
+
+    assert isinstance(result, GameSummary)
+    assert result.summary_markdown == "rule summary"
+    assert result.summary_type == "rule_based"
+    assert result.cached is False
 
 
 def test_summarize_game_ai(monkeypatch):
-    def fake_process_game_events(game_id):
-        assert game_id == 2
-        return ["event"]
-
-    def fake_get_or_build_stats_summary(game_id, events, date=None):
-        raise AssertionError("Rule-based summary should not be called")
-
     def fake_generate_ai_summary(play_by_play, game_story, editorial=None):
         assert play_by_play == ["event"]
         assert game_story == {"story": "data"}
         return "ai summary"
 
-    monkeypatch.setattr("engine.summarize_game.process_game_events", fake_process_game_events)
-    monkeypatch.setattr("engine.summarize_game.get_or_build_stats_summary", fake_get_or_build_stats_summary)
+    monkeypatch.setattr("engine.summarize_game.process_game_events", lambda gid: ["event"])
+    monkeypatch.setattr("engine.summarize_game.get_or_build_stats_summary",
+                        lambda **kw: (_ for _ in ()).throw(AssertionError("should not be called")))
     monkeypatch.setattr("engine.summarize_game.generate_ai_summary", fake_generate_ai_summary)
     monkeypatch.setattr("engine.summarize_game.get_play_by_play", lambda game_id: ["event"])
     monkeypatch.setattr("engine.summarize_game.get_game_story", lambda game_id: {"story": "data"})
     monkeypatch.setattr("engine.summarize_game.get_editorial", lambda game_id, **kw: None)
+    monkeypatch.setattr("engine.summarize_game.load_ai_summary", lambda game_id: None)
+    monkeypatch.setattr("engine.summarize_game.save_ai_summary", lambda **kw: None)
 
-    summary = engine.summarize_game.summarize_game(2, use_ai=True)
-    assert summary == "ai summary"
+    result = engine.summarize_game.summarize_game(2, use_ai=True)
+
+    assert isinstance(result, GameSummary)
+    assert result.summary_markdown == "ai summary"
+    assert result.summary_type == "ai"
+    assert result.cached is False
+
+
+def test_summarize_game_ai_cache_hit(monkeypatch):
+    monkeypatch.setattr("engine.summarize_game.load_ai_summary", lambda game_id: "cached text")
+
+    result = engine.summarize_game.summarize_game(3, use_ai=True)
+
+    assert result.summary_markdown == "cached text"
+    assert result.cached is True
+
+
+def test_summarize_game_ai_includes_editorial_fields(monkeypatch):
+    editorial = {"headline": "Big win", "summary": "Short recap.", "body": "Long body."}
+
+    monkeypatch.setattr("engine.summarize_game.load_ai_summary", lambda game_id: None)
+    monkeypatch.setattr("engine.summarize_game.get_play_by_play", lambda gid: {})
+    monkeypatch.setattr("engine.summarize_game.get_game_story", lambda gid: {})
+    monkeypatch.setattr("engine.summarize_game.get_editorial", lambda gid, **kw: editorial)
+    monkeypatch.setattr("engine.summarize_game.generate_ai_summary",
+                        lambda pbp, story, editorial=None: "summary")
+    monkeypatch.setattr("engine.summarize_game.save_ai_summary", lambda **kw: None)
+
+    result = engine.summarize_game.summarize_game(4, use_ai=True)
+
+    assert result.editorial_headline == "Big win"
+    assert result.editorial_summary == "Short recap."

--- a/tests/test_summarize_game.py
+++ b/tests/test_summarize_game.py
@@ -114,3 +114,14 @@ def test_summarize_game_ai_includes_editorial_fields(monkeypatch):
 
     assert result.editorial_headline == "Big win"
     assert result.editorial_summary == "Short recap."
+
+
+def test_summarize_game_fetch_failure_propagates(monkeypatch):
+    """Fetch errors propagate out of summarize_game so batch.py can catch and skip."""
+    monkeypatch.setattr("engine.summarize_game.load_ai_summary", lambda game_id: None)
+    monkeypatch.setattr("engine.summarize_game.get_play_by_play",
+                        lambda gid: (_ for _ in ()).throw(RuntimeError("network error")))
+
+    import pytest
+    with pytest.raises(RuntimeError, match="network error"):
+        engine.summarize_game.summarize_game(5, use_ai=True)


### PR DESCRIPTION
## Summary

- Introduces `GameSummary` (Pydantic v2) as the typed return value of `summarize_game`, replacing the plain `str`. Team/score fields are `Optional` — callers with a `GameSchedule` enrich via `model_copy`.
- `summarize_game` now tracks `cached` (True on GCS hit), and populates `editorial_headline`/`editorial_summary` from the editorial dict in the AI path.
- Adds `engine/batch.py` with `summarize_date(date, *, use_ai=True) -> list[GameSummary]`: fetches schedule, summarizes each game, enriches with team/score data, skips failures gracefully.
- `SummaryResult.summary` in `cli.py` is now typed `GameSummary`; print sites updated to `.summary_markdown`.
- Adds `pydantic` to `requirements.txt`.

## Test plan

- [ ] `python -m pytest tests/ -q` — 45 tests pass
- [ ] `python main.py` — CLI still prints text summary as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)